### PR TITLE
feat: draw_deck 工具新增 send 参数（#81）

### DIFF
--- a/docs/04-工具系统.md
+++ b/docs/04-工具系统.md
@@ -71,6 +71,8 @@
 | 音乐 | `music_play` |
 | 黑名单 | `suggest_block`(AI 建议拉黑,带冷却;默认需骰主用 `.ai block` 确认,可在工具配置关闭)、`unblock_user`、`get_block_list` |
 
+> 注：`draw_deck` 支持 `send` 参数——`true` 时直接把抽牌结果发送给用户；`false` 或省略（默认）时仅把结果返回给 AI，由 AI 转述，便于结合剧情再加工。
+
 外部注册:
 
 - MCP 工具:`<服务器名>_<工具名>`(见下节)。

--- a/src/tool/tools/seal.ts/tool_deck.ts
+++ b/src/tool/tools/seal.ts/tool_deck.ts
@@ -17,6 +17,10 @@ export function registerDeck() {
                     name: {
                         type: 'string',
                         description: "牌堆名称"
+                    },
+                    send: {
+                        type: 'boolean',
+                        description: "是否直接将抽牌结果发送给用户：true 时直接发送原始抽牌结果；false 或省略时返回结果由你转述，可结合剧情再加工"
                     }
                 },
                 required: ["name"]
@@ -24,7 +28,7 @@ export function registerDeck() {
         }
     });
     toolDraw.solve = async (ctx, msg, _, args) => {
-        const { name } = args;
+        const { name, send = false } = args;
 
         const dr = seal.deck.draw(ctx, name, true);
         if (!dr.exists) {
@@ -38,7 +42,9 @@ export function registerDeck() {
             return `牌堆${name}结果为空:${dr.err}`;
         }
 
-        seal.replyToSender(ctx, msg, result);
+        if (send) {
+            seal.replyToSender(ctx, msg, result);
+        }
         return result;
     }
 }


### PR DESCRIPTION
实现 issue #81，并保留"直接发送"的能力：

- 为 `draw_deck` 工具新增可选布尔参数 `send`：
  - `send = true`：直接把抽牌结果通过 `seal.replyToSender` 发送给用户（旧行为）。
  - `send = false` 或省略（默认）：仅把抽牌结果作为工具返回值交给 AI，由 AI 转述，可结合剧情再加工（issue #81 的诉求）。
- 参数为可选且默认 `false`，AI 无需显式指定即可获得"转述"行为。

说明：issue 中建议的 `return { content: result, images: [] }` 是旧架构的写法；当前架构下 `solve` 返回字符串即可，工具结果会自动作为回调消息喂回给 AI，无需单独返回 images。

同步内容：

- `docs/04-工具系统.md` 补充 `draw_deck` 的 `send` 参数说明

验证：`npm run lint`、`npx tsc --noEmit --strict`、`npm run build`、`npm run smoke` 全部通过。

Closes #81
