### PR TITLE
feat: 适配 anthropic 提供商请求/响应格式（#72）

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ max_tokens = 2048
 ```
 
 - `provider` / `base_url` 可以省略（deepseek / openai / google / zhipu / alibaba / anthropic / moonshot / xai / mistral / siliconflow 会自动识别），也可以显式填写 `base_url`；
+- `anthropic`（Claude）已适配请求/响应格式（system 拆出、tool_result 合并、响应归一化）；其流式暂不支持，配置 `stream = true` 时会自动回退为非流式；
 - 图片识别需要配置「图片模型」（`use = ["image-understanding"]`），向量记忆需要配置「嵌入模型」（`use = ["text-embedding"]`，输出维度需与「向量维度」配置一致）；
 - 默认对话模型取列表第一项，可在群里用 `.ai model <模型名>` 切换，`.ai model clr` 恢复默认。
 

--- a/docs/03-核心模块详解.md
+++ b/docs/03-核心模块详解.md
@@ -75,7 +75,7 @@
 - `chat.ts`:`ChatModel` 请求 `{baseUrl}/chat/completions`,解析 `choices[0].message`、`tool_calls`、`reasoning_content`。
 - `image.ts`:`ImageModel` 用于图片理解(`callITT`,图片 + prompt)与图片对话(`callChat`)。
 - `embedding.ts`:`EmbeddingModel` 请求 `{baseUrl}/embeddings`,带单条文本向量缓存。
-- `provider.ts`:`requestModel()` 统一请求入口:超时(`TIMEOUT`)、失败重试(最多 2 次,4xx 不重试,指数退避)、成功时上报 token 用量。
+- `provider.ts`:`requestModel()` 统一请求入口:超时(`TIMEOUT`)、失败重试(最多 2 次,4xx 不重试,指数退避)、成功时上报 token 用量;`adapter.ts` 按提供商转换请求/响应格式(当前支持 anthropic)。
 - `types.ts`:用途类型 `ChatModelUse('chat'|'compression'|'summarization')`、`ImageModelUse`、`EmbeddingModelUse('text-embedding')`。
 
 ## 请求服务(src/agent/stream.ts)

--- a/src/agent/stream.ts
+++ b/src/agent/stream.ts
@@ -2,12 +2,13 @@
 import Config from "../config/config";
 import { DEFAULT_CHAT_MODEL_BODY } from "../config/static_config";
 import { logger } from "../logger";
+import { buildProviderBody, parseProviderResponse } from "../model/adapter";
 import ChatModel from "../model/chat";
 import Model from "../model/model";
+import { requestModel } from "../model/provider";
 import { ToolCall } from "../tool/types";
 import { UsageManager } from "../usage";
 import { withTimeout } from "../utils/utils";
-import { fetchData } from "../utils/web";
 
 export class streamService {
     static async startStream(messages: any[], modelName: string = ''): Promise<string> {
@@ -84,7 +85,6 @@ export class streamService {
         tool_calls?: ToolCall[],
         tool_call_id?: string
     }[], tools: any[], tool_choice: string, modelName: string = ''): Promise<{ content: string, tool_calls: ToolCall[] }> {
-        const { TIMEOUT } = Config.base;
         const model = Model.getChatModel('chat', modelName) as ChatModel;
         if (!model) {
             logger.error('未找到可用的对话模型');
@@ -103,12 +103,11 @@ export class streamService {
             logger.printRequestMessages(body.messages);
 
             const time = Date.now();
-            const data = await withTimeout(() => fetchData(model.url, model.apiKey, body), TIMEOUT);
-            if (data.choices && data.choices.length > 0) {
-                UsageManager.updateUsage(data.model, data.usage);
-
-                const message = data.choices[0].message;
-                const finish_reason = data.choices[0].finish_reason;
+            const data = await requestModel(model.url, model.apiKey, buildProviderBody(model.provider, body), { provider: model.provider });
+            const response = parseProviderResponse(model.provider, data);
+            if (response.choices && response.choices.length > 0) {
+                const message = response.choices[0].message;
+                const finish_reason = response.choices[0].finish_reason;
 
                 if (Object.prototype.hasOwnProperty.call(message, 'reasoning_content')) {
                     logger.info('思维链内容:', message.reasoning_content);

--- a/src/model/adapter.ts
+++ b/src/model/adapter.ts
@@ -1,0 +1,179 @@
+// 模型适配层：不同 API 提供商的请求体与响应格式互转（当前支持 anthropic）
+import { ToolCall } from "../tool/types";
+
+export interface NormalizedChatResponse {
+    choices: Array<{
+        index: number,
+        finish_reason: string | null,
+        message: {
+            role: string,
+            content: string,
+            reasoning_content?: string,
+            tool_calls?: ToolCall[]
+        }
+    }>,
+    model?: string,
+    usage?: { prompt_tokens: number, completion_tokens: number, total_tokens: number }
+}
+
+const ANTHROPIC_FINISH_REASON_MAP: { [key: string]: string } = {
+    end_turn: 'stop',
+    stop_sequence: 'stop',
+    max_tokens: 'length',
+    tool_use: 'tool_calls',
+    pause_turn: 'stop',
+    refusal: 'content_filter'
+};
+
+/** 按提供商转换请求体：默认 OpenAI 兼容格式原样透传 */
+export function buildProviderBody(provider: string, body: any): any {
+    if (provider === 'anthropic') return buildAnthropicBody(body);
+    return body;
+}
+
+/** 按提供商归一化响应：默认 OpenAI 兼容格式原样透传 */
+export function parseProviderResponse(provider: string, data: any): NormalizedChatResponse {
+    if (provider === 'anthropic') return parseAnthropicResponse(data);
+    return data;
+}
+
+/** 提取统一格式的用量（兼容 anthropic 的 input/output_tokens 与 OpenAI 的 prompt/completion_tokens） */
+export function extractUsage(data: any): { prompt_tokens: number, completion_tokens: number, total_tokens: number } | undefined {
+    if (!data || !data.usage) return undefined;
+    const u = data.usage;
+    const prompt = u.input_tokens ?? u.prompt_tokens ?? 0;
+    const completion = u.output_tokens ?? u.completion_tokens ?? 0;
+    return {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: u.total_tokens ?? (prompt + completion)
+    };
+}
+
+/** OpenAI 格式请求体 → Anthropic Messages 格式 */
+function buildAnthropicBody(body: any): any {
+    const { system, messages } = buildAnthropicMessages(body.messages || []);
+    const out: any = {
+        model: body.model,
+        max_tokens: body.max_tokens ?? body.max_completion_tokens ?? 4096,
+        messages
+    };
+    if (system) out.system = system;
+    if (Array.isArray(body.tools) && body.tools.length > 0) {
+        out.tools = body.tools.map((t: any) => {
+            const fn = t.function || {};
+            return {
+                name: fn.name,
+                description: fn.description || '',
+                input_schema: fn.parameters || { type: 'object', properties: {} }
+            };
+        });
+    }
+    if (body.tool_choice) out.tool_choice = convertAnthropicToolChoice(body.tool_choice);
+    if (Array.isArray(body.stop) && body.stop.length > 0) out.stop_sequences = body.stop;
+    else if (typeof body.stop === 'string' && body.stop) out.stop_sequences = [body.stop];
+    if (typeof body.temperature === 'number') out.temperature = body.temperature;
+    if (typeof body.top_p === 'number') out.top_p = body.top_p;
+    if (typeof body.top_k === 'number') out.top_k = body.top_k;
+    if (body.stream) out.stream = true;
+    if (body.thinking) out.thinking = body.thinking;
+    if (body.metadata) out.metadata = body.metadata;
+    return out;
+}
+
+function convertAnthropicToolChoice(toolChoice: any): any {
+    if (toolChoice === 'required' || toolChoice === 'any') return 'any';
+    if (toolChoice === 'auto' || toolChoice === 'none') return toolChoice;
+    if (toolChoice && toolChoice.type === 'function') {
+        return { type: 'tool', name: toolChoice.function?.name };
+    }
+    return 'auto';
+}
+
+/** OpenAI messages → Anthropic messages（system 拆出、tool 结果合并为 user/tool_result、连续同角色合并） */
+function buildAnthropicMessages(messages: any[]): { system: string, messages: any[] } {
+    const systemParts: string[] = [];
+    const out: any[] = [];
+
+    for (const msg of messages || []) {
+        const role = msg.role;
+        if (role === 'system') {
+            const text = typeof msg.content === 'string' ? msg.content : '';
+            if (text) systemParts.push(text);
+            continue;
+        }
+        if (role === 'tool') {
+            const text = typeof msg.content === 'string' ? msg.content : String(msg.content || '');
+            out.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: msg.tool_call_id, content: text }] });
+            continue;
+        }
+        let content: any = msg.content;
+        if (role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+            const blocks: any[] = [];
+            if (msg.content) blocks.push({ type: 'text', text: typeof msg.content === 'string' ? msg.content : '' });
+            for (const tc of msg.tool_calls) {
+                let input: any = {};
+                try { input = JSON.parse(tc.function.arguments || '{}'); } catch { input = {}; }
+                blocks.push({ type: 'tool_use', id: tc.id, name: tc.function.name, input });
+            }
+            content = blocks;
+        }
+        out.push({ role, content });
+    }
+
+    // Anthropic 要求 user/assistant 交替，合并连续同角色消息
+    const merged: any[] = [];
+    for (const msg of out) {
+        const last = merged[merged.length - 1];
+        if (last && last.role === msg.role) {
+            last.content = mergeAnthropicContent(last.content, msg.content);
+        } else {
+            merged.push({ role: msg.role, content: msg.content });
+        }
+    }
+
+    return { system: systemParts.join('\n'), messages: merged };
+}
+
+function mergeAnthropicContent(a: any, b: any): any {
+    const toBlocks = (c: any): any[] => typeof c === 'string' ? [{ type: 'text', text: c }] : (Array.isArray(c) ? c : []);
+    return toBlocks(a).concat(toBlocks(b));
+}
+
+/** Anthropic Messages 响应 → OpenAI 兼容结构（choices/message/content/tool_calls） */
+function parseAnthropicResponse(data: any): NormalizedChatResponse {
+    const blocks = Array.isArray(data.content) ? data.content : [];
+    const content = blocks
+        .filter((b: any) => b.type === 'text')
+        .map((b: any) => b.text || '')
+        .join('');
+    const reasoningContent = blocks
+        .filter((b: any) => b.type === 'thinking')
+        .map((b: any) => b.thinking || '')
+        .join('');
+    const toolCalls: ToolCall[] = blocks
+        .filter((b: any) => b.type === 'tool_use')
+        .map((b: any, index: number) => ({
+            index,
+            id: b.id || '',
+            type: 'function' as const,
+            function: { name: b.name || '', arguments: JSON.stringify(b.input || {}) }
+        }));
+
+    const message: { role: string, content: string, reasoning_content?: string, tool_calls?: ToolCall[] } = {
+        role: data.role || 'assistant',
+        content
+    };
+    if (reasoningContent) message.reasoning_content = reasoningContent;
+    if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+    return {
+        choices: [{
+            index: 0,
+            finish_reason: ANTHROPIC_FINISH_REASON_MAP[data.stop_reason] || data.stop_reason || null,
+            message
+        }],
+        model: data.model,
+        usage: extractUsage(data)
+    };
+}

--- a/src/model/chat.ts
+++ b/src/model/chat.ts
@@ -4,6 +4,7 @@ import { DEFAULT_CHAT_MODEL_BODY } from "../config/static_config";
 import { logger } from "../logger";
 import { ToolCall } from "../tool/types";
 
+import { buildProviderBody, parseProviderResponse } from "./adapter";
 import { BaseModel } from "./model";
 import { requestModel } from "./provider";
 import { ChatModelUse, ModelBody, ModelUse } from "./types";
@@ -16,7 +17,7 @@ export default class ChatModel extends BaseModel {
     }
 
     get url() {
-        return `${this.baseUrl}/chat/completions`;
+        return this.provider === 'anthropic' ? `${this.baseUrl}/messages` : `${this.baseUrl}/chat/completions`;
     }
 
     async callChat(agent: Agent, sessionId: string): Promise<{ content: string, tool_calls: ToolCall[] }> {
@@ -29,10 +30,11 @@ export default class ChatModel extends BaseModel {
             logger.printRequestMessages(body.messages)
 
             const time = Date.now();
-            const data = await requestModel(this.url, this.apiKey, body);
-            if (data.choices && data.choices.length > 0) {
-                const message = data.choices[0].message;
-                const finish_reason = data.choices[0].finish_reason;
+            const data = await requestModel(this.url, this.apiKey, buildProviderBody(this.provider, body), { provider: this.provider });
+            const response = parseProviderResponse(this.provider, data);
+            if (response.choices && response.choices.length > 0) {
+                const message = response.choices[0].message;
+                const finish_reason = response.choices[0].finish_reason;
 
                 if (Object.prototype.hasOwnProperty.call(message, 'reasoning_content')) {
                     logger.info(`思维链内容:`, message.reasoning_content);

--- a/src/model/provider.ts
+++ b/src/model/provider.ts
@@ -5,21 +5,30 @@ import { UsageManager } from "../usage";
 import { withTimeout } from "../utils/utils";
 import { fetchData } from "../utils/web";
 
+import { extractUsage } from "./adapter";
+
 const MAX_RETRIES = 2;
+
+export interface RequestModelOptions {
+    /** API 提供商：anthropic 使用 x-api-key 请求头与 /messages 协议 */
+    provider?: string;
+}
 
 /**
  * 发起模型请求：带超时、失败重试（4xx 不重试）与用量上报。
  * @returns 解析后的响应体
  */
-export async function requestModel(url: string, apiKey: string, body: any): Promise<any> {
+export async function requestModel(url: string, apiKey: string, body: any, options: RequestModelOptions = {}): Promise<any> {
     const { TIMEOUT } = Config.base;
+    const { provider = '' } = options;
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         try {
-            const data = await withTimeout(() => fetchData(url, apiKey, body), TIMEOUT);
-            if (data && data.usage) {
-                UsageManager.updateUsage(data.model || '', data.usage);
+            const data = await withTimeout(() => fetchProvider(provider, url, apiKey, body), TIMEOUT);
+            const usage = extractUsage(data);
+            if (usage) {
+                UsageManager.updateUsage(data.model || '', usage);
             }
             return data;
         } catch (e) {
@@ -35,4 +44,33 @@ export async function requestModel(url: string, apiKey: string, body: any): Prom
         }
     }
     throw lastError;
+}
+
+/** 按提供商发起请求：anthropic 使用 x-api-key 与 anthropic-version 请求头 */
+async function fetchProvider(provider: string, url: string, apiKey: string, body: any): Promise<any> {
+    if (provider !== 'anthropic') return fetchData(url, apiKey, body);
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        },
+        body: JSON.stringify(body)
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+        throw new Error(`请求失败! 状态码: ${response.status}\n响应体:${text}`);
+    }
+    if (!text) {
+        throw new Error("响应体为空");
+    }
+    try {
+        return JSON.parse(text);
+    } catch (e) {
+        throw new Error(`解析响应体时出错:${e instanceof Error ? e.message : String(e)}\n响应体:${text}`);
+    }
 }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -330,7 +330,10 @@ export class Session {
         this.resetState();
 
         const model = Model.getChatModel('chat', this.setting.modelName);
-        if (model && (model.body as any).stream === true) {
+        if (model && model.provider === 'anthropic' && (model.body as any).stream === true) {
+            logger.warning(`anthropic 提供商（${model.name}）暂不支持流式输出，已自动切换为非流式`);
+        }
+        if (model && (model.body as any).stream === true && model.provider !== 'anthropic') {
             await this.chatStream(ctx, msg);
             this.save();
             return;


### PR DESCRIPTION
实现 issue #72 备忘录中确定的「anthropic 格式适配」与「response 格式适配」。

改动：

- 新增 `src/model/adapter.ts` 适配层：
  - `buildProviderBody`：OpenAI 兼容请求体 → Anthropic Messages 格式（system 拆出到顶层、tool 结果合并为 `user/tool_result`、assistant 的 `tool_calls` 转 `tool_use` 块、`tools` 转 `input_schema`、`tool_choice` 映射、`stop` 转 `stop_sequences` 等）。
  - `parseProviderResponse`：Anthropic 响应归一化为 OpenAI 兼容结构（text 块拼接为 content、thinking 块→`reasoning_content`、`tool_use`→`tool_calls`、`stop_reason`→`finish_reason`）。
  - `extractUsage`：统一用量字段（兼容 `input/output_tokens` 与 `prompt/completion_tokens`）。
- `src/model/provider.ts`：`requestModel` 支持 `provider` 选项；anthropic 使用 `x-api-key` + `anthropic-version` 请求头并走 `/messages` 端点；用量按统一格式上报。
- `src/model/chat.ts`：anthropic 时 `url` 指向 `/messages`，`callChat` 走适配层。
- `src/agent/stream.ts`：主对话路径 `sendChatRequest`（含子智能体 `Agent.chat`）统一走适配层。
- `src/session/session.ts`：anthropic 配置 `stream = true` 时自动回退非流式并提示（流式走 OpenAI 兼容后端，暂不支持 anthropic）。
- 其他 OpenAI 兼容提供商原样透传，不受影响。

验证：`npm run lint`、`npx tsc --noEmit --strict`、`npm run build`、`npm run smoke` 全部通过；另用独立脚本实测请求转换、响应归一、用量提取与 user/assistant 角色交替，全部 PASS。

Closes #72
