### PR TITLE
feat: 发布时打包本体豹包与含依赖插件的完整豹包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,7 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: bash
         run: |
-          version="$(node scripts/prepare-sealpack.js)"
-          npx sealpack pack sealpack --out "dist/aiplugin4-${version}.sealpack"
+          node scripts/build-release.js
 
       - name: Upload build artifacts
         if: github.event_name != 'pull_request'
@@ -73,6 +72,7 @@ jobs:
             dist/*.sealpack
             dist/aiplugin4.js
             sealpack/**
+            sealpack-full/**
 
   publish-sealrepo:
     if: startsWith(github.ref, 'refs/tags/')
@@ -96,11 +96,21 @@ jobs:
         with:
           name: release-assets-${{ github.run_id }}
 
+      - name: Prepare release packages
+        run: node scripts/build-release.js
+
       - name: Publish to SealRepo
         env:
           SEALPACK_TOKEN: ${{ secrets.SEALPACK_TOKEN }}
         run: >-
           npx sealpack publish sealpack
+          --server "${SEALPACK_SERVER}"
+
+      - name: Publish full bundle to SealRepo
+        env:
+          SEALPACK_TOKEN: ${{ secrets.SEALPACK_TOKEN }}
+        run: >-
+          npx sealpack publish sealpack-full
           --server "${SEALPACK_SERVER}"
 
   github-release:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn.lock
 dist/
 dev/
 sealpack/scripts/
+sealpack-full/
 skills/**/.env
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -533,10 +533,11 @@ aiplugin4/
 │   ├── update.ts         # 版本更新日志
 │   └── usage.ts          # token 用量统计与图表
 ├── tools/                # 构建脚本（build.js / build-config.js）
-├── scripts/              # smoke.js 冒烟、prepare-sealpack.js 打包同步、release-notes.js 发布正文
+├── scripts/              # smoke.js 冒烟、prepare-sealpack.js / build-release.js 打包、deps.cjs 依赖清单、release-notes.js 发布正文
 ├── types/                # seal.d.ts（SealDice API 类型定义）
 ├── dist/                 # 构建产物 aiplugin4.js
-├── sealpack/             # SealRepo 打包源（info.toml / assets/icon.png，scripts/main.js 自动同步）
+├── sealpack/             # 本体 SealRepo 打包源（info.toml / assets/icon.png，scripts/main.js 自动同步）
+├── sealpack-full/        # 完整包打包源（生成目录：本体 + 依赖插件，已 gitignore）
 ├── 相关后端项目/         # 配套后端服务源码
 ├── .github/workflows/    # build-check.yml / release.yml
 ├── header.txt            # 打包时拼接到产物头部的 UserScript 注释
@@ -553,6 +554,7 @@ npm run smoke       # 冒烟：在 Node 中用 seal 桩加载 dist/aiplugin4.js
 npm run lint        # ESLint 检查 src/**/*.ts
 npm run package:check  # 构建 + 同步 sealpack 源 + 校验包格式与体积
 npm run pack:sealpack  # 打包 → dist/aiplugin4.sealpack
+npm run pack:release   # 发布打包：本体 JS + 本体豹包 + 完整豹包（含依赖插件）
 ```
 
 构建使用 esbuild，入口 `src/index.ts`，`external: ['csharp','puerts']`；生产构建不压缩，保持可读、便于用户自行查错。改完核心逻辑建议执行 `npm run build && npm run smoke`。
@@ -647,10 +649,11 @@ await api.run(ctx, msg, { agentName: 'kp_agent', reason: 'KP插件调用' });
 - `.github/workflows/build-check.yml`：main 分支 push / PR 时执行 lint、tsc strict、构建并校验 sealpack 包、冒烟测试；
 - `.github/workflows/release.yml`：推送 `v*` 标签（如 `v4.13.0`）时自动发版：
   1. verify：lint / tsc / `npm run package:check`（构建 + sealpack 校验）/ 冒烟，并校验标签与 `VERSION`、`update.ts` 版本日志一致；
-  2. 打包 `.sealpack`（`sealpack pack sealpack`）并上传构建产物；
-  3. publish-sealrepo：用 `SEALPACK_TOKEN` 发布到 [SealRepo](https://repo.sealdice.com/)；
-  4. github-release：从 `src/update.ts` 提取对应版本日志作为 Release 正文，附带 `aiplugin4-v<版本>.sealpack` 与 `dist/aiplugin4.js`。
-- 打包源在 `sealpack/`：`scripts/main.js` 为构建产物自动同步，`info.toml` 的版本由 `scripts/prepare-sealpack.js` 自动同步；
+  2. `node scripts/build-release.js` 产出三类发布物并上传：`dist/aiplugin4.js`（本体 JS）、`aiplugin4-v<版本>.sealpack`（只含本体的豹包）、`aiplugin4-full-v<版本>.sealpack`（本体 + 依赖插件的完整豹包）；
+  3. publish-sealrepo：用 `SEALPACK_TOKEN` 把本体包与完整包分别发布到 [SealRepo](https://repo.sealdice.com/)；
+  4. github-release：从 `src/update.ts` 提取对应版本日志作为 Release 正文，附带两个豹包与 `dist/aiplugin4.js`。
+- 打包源：`sealpack/` 为本体（`scripts/main.js` 与 `info.toml` 版本由 `scripts/prepare-sealpack.js` 自动同步）；`sealpack-full/` 为完整包（生成目录，复制本体并下载依赖插件）；
+- 完整包依赖插件：在 `scripts/deps.cjs` 的 `dependencies` 中配置 `url`（依赖插件 JS 的 raw 地址）与可选 `filename`，当前为空待补充；下载失败会导致发版失败；
 - SealRepo 发布 Token：仓库 Settings → Secrets and variables → Actions → 新建 `SEALPACK_TOKEN`（值在 repo.sealdice.com 后台复制）；包图标放 `sealpack/assets/icon.png`（`info.toml` 已引用）；
 - 发版前需同步：`src/config/static_config.ts` 的 `VERSION`、`header.txt` 的 `@version`、`src/update.ts` 的 `updateInfo`（并确认 `updateInfo` 含新版本条目）。
 

--- a/docs/07-开发指南.md
+++ b/docs/07-开发指南.md
@@ -174,9 +174,9 @@ api.registerTool({
 `.github/workflows/`:
 
 - `build-check.yml`:main 分支 push / PR 时执行 lint、tsc strict、构建并校验 sealpack(`npm run package:check`)、冒烟测试。
-- `release.yml`:推送 `v*` 标签时自动发版——verify(校验标签与 `VERSION`/`update.ts` 一致)→ 打包 `.sealpack` → 用 `SEALPACK_TOKEN` 发布 SealRepo → 从 `src/update.ts` 提取版本日志作为 GitHub Release 正文,附带 `aiplugin4-v<版本>.sealpack` 与 `dist/aiplugin4.js`。
+- `release.yml`:推送 `v*` 标签时自动发版——verify(校验标签与 `VERSION`/`update.ts` 一致)→ `node scripts/build-release.js` 打包(本体 JS + 本体豹包 + 完整豹包)→ 用 `SEALPACK_TOKEN` 分别发布两个豹包到 SealRepo → 从 `src/update.ts` 提取版本日志作为 GitHub Release 正文,附带两个豹包与 `dist/aiplugin4.js`。
 
-打包源 `sealpack/`:`scripts/main.js` 与 `info.toml` 版本由 `scripts/prepare-sealpack.js` 自动同步;包图标放 `sealpack/assets/icon.png`;SealRepo Token 放 GitHub Actions secrets(`SEALPACK_TOKEN`)。
+打包源 `sealpack/`:`scripts/main.js` 与 `info.toml` 版本由 `scripts/prepare-sealpack.js` 自动同步;`sealpack-full/` 为完整包生成目录(复制本体 + 下载依赖插件,已 gitignore)。完整包依赖插件在 `scripts/deps.cjs` 的 `dependencies` 中配置(`url` 为依赖插件 JS 的 raw 地址,可选 `filename`),当前为空待补充。包图标放 `sealpack/assets/icon.png`;SealRepo Token 放 GitHub Actions secrets(`SEALPACK_TOKEN`)。
 
 发版前记得同步:`src/config/static_config.ts` 的 `VERSION`、`header.txt` 的 `@version`、`src/update.ts` 的 `updateInfo`(且需包含新版本条目)。
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "smoke": "node scripts/smoke.js",
     "lint": "eslint \"src/**/*.ts\"",
     "package:check": "npm run build && node scripts/prepare-sealpack.js && sealpack validate sealpack && sealpack size sealpack",
-    "pack:sealpack": "node scripts/prepare-sealpack.js && sealpack pack sealpack --out dist/aiplugin4.sealpack"
+    "pack:sealpack": "node scripts/prepare-sealpack.js && sealpack pack sealpack --out dist/aiplugin4.sealpack",
+    "pack:release": "node scripts/build-release.js"
   },
   "engines": {
     "node": ">=10"

--- a/scripts/build-release.js
+++ b/scripts/build-release.js
@@ -1,0 +1,152 @@
+// 发布打包：产出三类发布物
+//   1. dist/aiplugin4.js                  本体 JS（由 npm run build 生成）
+//   2. dist/aiplugin4-<版本>.sealpack     只含本体的豹包
+//   3. dist/aiplugin4-full-<版本>.sealpack 包含本体与依赖插件的完整豹包
+// 依赖插件地址在 scripts/deps.cjs 中配置（当前为空，待补充）。
+const { execFile, execSync } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const bundle = path.join(root, 'dist', 'aiplugin4.js');
+const sealpackDir = path.join(root, 'sealpack');
+const fullDir = path.join(root, 'sealpack-full');
+const depsFile = path.join(__dirname, 'deps.cjs');
+
+const FULL_PACKAGE_ID = 'error2913/aiplugin4-full';
+const FULL_PACKAGE_NAME = 'aiplugin4-full';
+const FULL_PACKAGE_DESC = 'aiplugin4 完整包：包含本体与依赖插件，安装即用';
+
+function getVersion() {
+  const src = fs.readFileSync(path.join(root, 'src', 'config', 'static_config.ts'), 'utf8');
+  const m = src.match(/VERSION\s*=\s*["']([^"']+)["']/);
+  if (!m) {
+    console.error('未能在 src/config/static_config.ts 中找到 VERSION');
+    process.exit(1);
+  }
+  return m[1];
+}
+
+function run(cmd, cwd = root) {
+  execSync(cmd, { stdio: 'inherit', cwd });
+}
+
+function downloadWithCurl(url) {
+  return new Promise((resolve, reject) => {
+    const args = ['-fsSL', '--max-time', '120'];
+    // Windows 的 schannel 在部分网络下会因吊销检查失败，跳过吊销检查（证书链校验保留）
+    if (process.platform === 'win32') args.push('--ssl-no-revoke');
+    args.push(url);
+    execFile('curl', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }, (err, stdout) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function downloadWithNode(url) {
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https:') ? https : http;
+    lib.get(url, { headers: { 'User-Agent': 'aiplugin4-release' } }, res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`HTTP ${res.statusCode}`));
+        res.resume();
+        return;
+      }
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => resolve(data));
+    }).on('error', reject);
+  });
+}
+
+async function download(url) {
+  try {
+    return await downloadWithCurl(url);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      // 环境没有 curl 时回退到 Node 内置 https
+      return downloadWithNode(url);
+    }
+    throw e;
+  }
+}
+
+async function main() {
+  const version = getVersion();
+
+  if (!fs.existsSync(bundle)) {
+    console.error(`构建产物不存在: ${bundle}，请先执行 npm run build`);
+    process.exit(1);
+  }
+
+  // 1. 准备本体 sealpack 源目录（同步版本、复制 main.js）
+  console.log('[build-release] 准备本体豹包源...');
+  run(`node "${path.join(__dirname, 'prepare-sealpack.js')}"`);
+
+  // 2. 构建完整包源目录：复制本体内容 + 下载依赖插件
+  console.log('[build-release] 准备完整豹包源...');
+  fs.rmSync(fullDir, { recursive: true, force: true });
+  fs.mkdirSync(fullDir, { recursive: true });
+  for (const entry of fs.readdirSync(sealpackDir)) {
+    fs.cpSync(path.join(sealpackDir, entry), path.join(fullDir, entry), { recursive: true });
+  }
+
+  const deps = require(depsFile).dependencies || [];
+  if (deps.length === 0) {
+    console.warn('[build-release] scripts/deps.cjs 未配置依赖插件，完整包暂只包含本体');
+  } else {
+    fs.mkdirSync(path.join(fullDir, 'scripts'), { recursive: true });
+    for (const dep of deps) {
+      if (!dep.url) {
+        console.error(`依赖插件 ${dep.name || '?'} 缺少 url`);
+        process.exit(1);
+      }
+      const base = path.basename(dep.url);
+      const filename = (dep.filename || base).replace(/[^\w.-]/g, '_');
+      if (!filename.endsWith('.js')) {
+        console.error(`依赖插件 ${dep.name || filename} 的文件名必须为 .js 结尾，当前: ${filename}`);
+        process.exit(1);
+      }
+      console.log(`[build-release] 下载依赖插件: ${dep.name || filename} <- ${dep.url}`);
+      try {
+        const content = await download(dep.url);
+        fs.writeFileSync(path.join(fullDir, 'scripts', filename), content);
+      } catch (e) {
+        console.error(`下载依赖插件失败: ${dep.url}（${e instanceof Error ? e.message : String(e)}）`);
+        process.exit(1);
+      }
+    }
+  }
+
+  // 3. 修改完整包元数据（独立包 id，避免与本体包在 SealRepo 冲突）
+  const fullToml = path.join(fullDir, 'info.toml');
+  const toml = fs.readFileSync(fullToml, 'utf8')
+    .replace(/^id\s*=\s*".*"$/m, `id = "${FULL_PACKAGE_ID}"`)
+    .replace(/^name\s*=\s*".*"$/m, `name = "${FULL_PACKAGE_NAME}"`)
+    .replace(/^description\s*=\s*".*"$/m, `description = "${FULL_PACKAGE_DESC}"`);
+  fs.writeFileSync(fullToml, toml);
+
+  // 4. 校验并打包两个豹包
+  console.log('[build-release] 校验并打包...');
+  run('npx --no-install sealpack validate sealpack');
+  run('npx --no-install sealpack validate sealpack-full');
+  run(`npx --no-install sealpack pack sealpack --out "dist/aiplugin4-${version}.sealpack"`);
+  run(`npx --no-install sealpack pack sealpack-full --out "dist/aiplugin4-full-${version}.sealpack"`);
+
+  console.log(`[build-release] 完成：
+  - dist/aiplugin4.js
+  - dist/aiplugin4-${version}.sealpack
+  - dist/aiplugin4-full-${version}.sealpack（${deps.length} 个依赖插件）`);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/deps.cjs
+++ b/scripts/deps.cjs
@@ -10,5 +10,21 @@
 //   filename: "ob11.js"
 // }
 module.exports = {
-  dependencies: []
+  dependencies: [
+    {
+      name: "ob11 网络连接依赖",
+      url: "https://raw.githubusercontent.com/error2913/sealdice-plugin-ob11-net-connection/main/dist/ob11%E7%BD%91%E7%BB%9C%E8%BF%9E%E6%8E%A5%E4%BE%9D%E8%B5%96.js",
+      filename: "ob11-net-connection.js"
+    },
+    {
+      name: "AITTS",
+      url: "https://raw.githubusercontent.com/baiyu-yu/plug-in/main/AITTS.js",
+      filename: "AITTS.js"
+    },
+    {
+      name: "AIDrawing",
+      url: "https://raw.githubusercontent.com/baiyu-yu/plug-in/main/AIDrawing.js",
+      filename: "AIDrawing.js"
+    }
+  ]
 };

--- a/scripts/deps.cjs
+++ b/scripts/deps.cjs
@@ -1,0 +1,14 @@
+// 完整包依赖插件清单（build-release.js 会读取本文件并下载到 sealpack-full/scripts/）
+// url:      依赖插件 JS 的原始地址（raw 链接），支持 http/https
+// filename: 打包后的文件名（可省略，默认取 URL 文件名，只保留 .js 后缀的合法文件名）
+// name:     仅用于日志展示
+//
+// 示例（取消注释并按实际地址填写）：
+// {
+//   name: "ob11 网络连接依赖",
+//   url: "https://raw.githubusercontent.com/owner/repo/main/ob11.js",
+//   filename: "ob11.js"
+// }
+module.exports = {
+  dependencies: []
+};


### PR DESCRIPTION
发布打包支持从其他仓库拉取依赖插件并产出完整豹包。

改动：

- 新增 `scripts/deps.cjs`：完整包依赖插件清单（`url` 为依赖插件 JS 的 raw 地址，可选 `filename`/`name`），已填入 ob11 网络连接依赖、AITTS、AIDrawing 三个依赖插件。
- 新增 `scripts/build-release.js`（`npm run pack:release`）：一次产出三类发布物
  - `dist/aiplugin4.js`（本体 JS，由 `npm run build` 生成）
  - `dist/aiplugin4-<版本>.sealpack`（只含本体的豹包）
  - `dist/aiplugin4-full-<版本>.sealpack`（本体 + 依赖插件的完整豹包）
- 完整包生成目录 `sealpack-full/`：复制本体打包源 → 按 `deps.cjs` 下载依赖 JS 到 `scripts/` → 修改 `info.toml` 元数据（id 改为 `error2913/aiplugin4-full`，避免与本体包在 SealRepo 冲突）→ 校验并打包。目录已加入 `.gitignore`。
- 下载实现：优先 curl（Windows 加 `--ssl-no-revoke` 解决吊销检查失败），无 curl 回退 Node https；依赖下载失败会让发版失败，避免产出不完整包。
- `.github/workflows/release.yml`：发版时用 `build-release.js` 打包两个豹包并上传；publish 阶段分别发布本体包与完整包到 SealRepo；GitHub Release 附带两个豹包 + JS。
- README、docs/07 已同步发布流程与依赖清单填写位置。

待办：依赖插件地址拿到后，填入 `scripts/deps.cjs` 的 `dependencies` 即可，无需再改代码。
