### PR TITLE
fix: eslint 忽略 examples/scripts 目录，修复非 tsconfig 内 JS 解析报错

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,9 @@
   "ignorePatterns": [
     "node_modules",
     "build",
-    "coverage"
+    "coverage",
+    "examples",
+    "scripts"
   ],
   "plugins": [
     "import",


### PR DESCRIPTION
修复 ESLint 对非 tsconfig 内 JS 文件的解析报错。

原因：`.eslintrc.json` 根级配置了 `parserOptions.project: tsconfig.json`，编辑器或全量扫描 lint 到 `examples/use-aiplugin4.js` 等 JS 文件时，该文件不在 tsconfig include 中，触发 typescript-eslint 的解析错误。

改动：在 `ignorePatterns` 中加入 `examples` 与 `scripts`（均为不在 tsconfig 内的 JS 工具/示例文件，`npm run lint` 本就只覆盖 `src/**/*.ts`）。

验证：`npm run lint` 正常；显式 lint `examples/` 与 `scripts/` 不再报解析错误（仅提示已忽略）。
