### PR TITLE
feat: .ai tool call 返回内容过长时仅记录日志并提示

### DIFF
--- a/src/cmd/sub_cmd/tool.ts
+++ b/src/cmd/sub_cmd/tool.ts
@@ -127,8 +127,14 @@ export function registerCmdTool() {
 
                     const content = await tool.solve(ctx, msg, session, args);
                     logger.info(`[tool] 指令调用 session=${session.sessionId} tool=${val3}`);
-                    seal.replyToSender(ctx, msg, `返回内容:
+                    const MAX_TOOL_CALL_OUTPUT_LENGTH = 500;
+                    if (content.length > MAX_TOOL_CALL_OUTPUT_LENGTH) {
+                        logger.info(`[tool] 返回内容过长(${content.length}字符)，已仅记录日志，未发送:\n${content}`);
+                        seal.replyToSender(ctx, msg, `返回内容过长（${content.length} 字符），未发送，已记录到海豹日志（[tool] 指令调用 tool=${val3}）`);
+                    } else {
+                        seal.replyToSender(ctx, msg, `返回内容:
       ${content}`);
+                    }
                     return ret;
                 } catch (e) {
                     const s = `调用函数 (${val3}) 失败:${e instanceof Error ? e.message : String(e)}`;


### PR DESCRIPTION
`.ai tool call <函数名>` 直接试用工具时，若返回内容超过 500 字符，不再把整段内容发到群里，改为：

- 完整内容仅记录到海豹日志（`[tool] 返回内容过长(...)，已仅记录日志，未发送:`）
- 群里只回一条提示：`返回内容过长（N 字符），未发送，已记录到海豹日志（[tool] 指令调用 tool=xxx）`

实测（线上）：`forum_get_posts` 返回 4517 字符 → 群里只收到提示，完整列表在日志中可查。

阈值硬编码 500。lint / tsc strict / build / smoke 全绿。
