### PR TITLE
chore: sealpack 包名改为 AI骰娘4 / AI骰娘4-扩展

### DIFF
--- a/scripts/build-release.js
+++ b/scripts/build-release.js
@@ -16,8 +16,8 @@ const fullDir = path.join(root, 'sealpack-full');
 const depsFile = path.join(__dirname, 'deps.cjs');
 
 const FULL_PACKAGE_ID = 'error2913/aiplugin4-full';
-const FULL_PACKAGE_NAME = 'aiplugin4-full';
-const FULL_PACKAGE_DESC = 'aiplugin4 完整包：包含本体与依赖插件，安装即用';
+const FULL_PACKAGE_NAME = 'AI骰娘4-扩展';
+const FULL_PACKAGE_DESC = 'AI骰娘4 扩展包（完整包）：包含本体与依赖插件，安装即用';
 
 function getVersion() {
   const src = fs.readFileSync(path.join(root, 'src', 'config', 'static_config.ts'), 'utf8');

--- a/sealpack/info.toml
+++ b/sealpack/info.toml
@@ -6,7 +6,7 @@ format_version = "1.0.0"
 # 构建时会由 scripts/prepare-sealpack.js 自动同步。
 [package]
 id = "error2913/aiplugin4"
-name = "aiplugin4"
+name = "AI骰娘4"
 version = "4.13.2"
 authors = ["错误、白鱼"]
 license = "MIT"


### PR DESCRIPTION
将 sealpack 包的展示名改为中文：

- 本体包：name = "AI骰娘4"（id 保持 error2913/aiplugin4）
- 完整包：name = "AI骰娘4-扩展"（id 保持 error2913/aiplugin4-full）
- 完整包描述同步为「AI骰娘4 扩展包（完整包）」

改动文件：sealpack/info.toml、scripts/build-release.js。
两个包均已本地 build-release 验证通过。