### PR TITLE
feat: 工具按需加载（search_tools 发现 + call_tool 统一执行，仅核心工具常驻）

### DIFF
--- a/src/tool/tool.ts
+++ b/src/tool/tool.ts
@@ -305,6 +305,12 @@ export default class Tool {
         return tools;
     }
 
+    /** 全部可用工具：核心常驻 + 按需加载（均已开启且匹配会话类型），供 search_tools 列名/查详情 */
+    static getAvailableTools(session: Session): ToolInfo[] {
+        const core = this.getToolsInfo(session) || [];
+        return core.concat(this.getOnDemandTools(session));
+    }
+
     static getToolsInfoPrompt(session: Session): string {
         const { PROMPT_ENGINEERING } = Config.tool;
         const { TOOLS_PROMPT_TEMPLATE } = Config.prompt;

--- a/src/tool/tool.ts
+++ b/src/tool/tool.ts
@@ -16,6 +16,17 @@ export const toolMap: { [key: string]: Tool } = {};
 export type ToolName = string;
 export type ToolState = { [key: string]: boolean };
 
+// 核心常驻工具：始终注入函数 schema，保证基本对话能力与“发现/执行”入口；
+// 其余工具按需加载：AI 先用 search_tools 查找工具，再用 call_tool 执行，避免全量工具定义浪费 token
+export const CORE_TOOL_NAMES: string[] = [
+    'search_tools', // 按需发现工具（返回完整参数说明）
+    'call_tool',    // 统一执行入口（调用任意已开启工具）
+    'use_skill',    // 技能调用
+    'run_command',  // 海豹指令调用
+    'get_cmd_help', // 指令帮助
+    'get_time'      // 当前时间
+];
+
 export default class Tool {
     toolInfo: ToolInfo;
     ExtCmdInfo: ExtCmdInfo; // 海豹指令信息
@@ -258,6 +269,7 @@ export default class Tool {
         const sessionType = session.sessionType;
         const tools = Object.keys(toolState)
             .map(key => {
+                if (!CORE_TOOL_NAMES.includes(key)) return null; // 非核心工具按需加载，不注入 schema
                 if (toolState[key]) {
                     if (!Object.prototype.hasOwnProperty.call(toolMap, key)) {
                         Logger.warning(`在getToolsInfo中找不到工具:${key}`);
@@ -274,6 +286,25 @@ export default class Tool {
 
         return tools.length > 0 ? tools : null;
     }
+
+    /** 按需加载工具：非核心且当前会话已开启的工具，供 search_tools 发现 */
+    static getOnDemandTools(session: Session): ToolInfo[] {
+        const toolState = session.toolState;
+        const sessionType = session.sessionType;
+        const tools: ToolInfo[] = [];
+        for (const key of Object.keys(toolState)) {
+            if (CORE_TOOL_NAMES.includes(key) || !toolState[key]) continue;
+            if (!Object.prototype.hasOwnProperty.call(toolMap, key)) {
+                Logger.warning(`在getOnDemandTools中找不到工具:${key}`);
+                continue;
+            }
+            const tool: Tool = toolMap[key];
+            if (tool.sessionType !== "any" && tool.sessionType !== sessionType) continue;
+            tools.push(tool.toolInfo);
+        }
+        return tools;
+    }
+
     static getToolsInfoPrompt(session: Session): string {
         const { PROMPT_ENGINEERING } = Config.tool;
         const { TOOLS_PROMPT_TEMPLATE } = Config.prompt;
@@ -291,6 +322,17 @@ export default class Tool {
                 "PROMPT_ENGINEERING": PROMPT_ENGINEERING,
                 "tools": flatTools
             });
+        }
+
+        // 按需工具：只给名称 + 一行描述，详细参数通过 search_tools 获取，控制 token 占用
+        const onDemand = this.getOnDemandTools(session);
+        if (onDemand.length > 0) {
+            const summaries = onDemand.map((t, i) => {
+                const desc = t.function.description.replace(/\s+/g, ' ').trim();
+                const truncated = desc.length > 120 ? desc.slice(0, 120) + '…' : desc;
+                return `${i + 1}. ${t.function.name}：${truncated}`;
+            });
+            s += `\n\n## 其他可用工具（按需加载）\n${summaries.join('\n')}\n需要使用上述工具时，先调用 search_tools 获取参数说明，再通过 call_tool 执行。`;
         }
         return s;
     }

--- a/src/tool/tools/init.ts
+++ b/src/tool/tools/init.ts
@@ -6,6 +6,7 @@ import { registerSealTools } from "./seal.ts/init";
 import { registerBlockTool } from "./tool_block";
 import { registerCmdTool } from "./tool_cmd";
 import { registerContext } from "./tool_context";
+import { registerDispatchTools } from "./tool_dispatch";
 import { registerForum } from "./tool_forum";
 import { registerMemory } from "./tool_memory";
 import { registerMessage } from "./tool_message";
@@ -31,4 +32,5 @@ export function registerTools() {
     registerBlockTool();
     registerCmdTool();
     registerForum();
+    registerDispatchTools();
 }

--- a/src/tool/tools/tool_dispatch.ts
+++ b/src/tool/tools/tool_dispatch.ts
@@ -1,0 +1,124 @@
+// 按需加载调度工具：search_tools（发现工具）+ call_tool（统一执行）
+// 非核心工具不再全量注入函数 schema；AI 先搜索工具获得参数说明，再通过 call_tool 执行，
+// 大幅降低每轮请求中工具定义占用的 token
+import Config from "../../config/config";
+import Logger from "../../logger";
+import { Session } from "../../session/session";
+import { withTimeout } from "../../utils/utils";
+import Tool, { toolMap } from "../tool";
+
+const MAX_SEARCH_RESULTS = 8; // search_tools 单次返回工具数上限
+
+export function registerDispatchTools() {
+    // 工具发现：返回匹配工具的完整 schema（含参数说明），供 call_tool 使用
+    const searchTool = new Tool({
+        type: "function",
+        function: {
+            name: "search_tools",
+            description: `搜索当前会话可用的工具，返回工具的名称、描述与完整参数说明。需要调用未直接在函数列表中提供的工具时，先调用本工具获取参数格式，再通过 call_tool 执行。query 留空时返回全部可用工具的简表。`,
+            parameters: {
+                type: "object",
+                properties: {
+                    query: {
+                        type: "string",
+                        description: "搜索关键词，匹配工具名称或描述；留空返回全部可用工具简表"
+                    },
+                    limit: {
+                        type: "integer",
+                        description: "最多返回的工具数，默认 8，最大 20"
+                    }
+                },
+                required: []
+            }
+        }
+    });
+    searchTool.solve = async (_ctx, _msg, session: Session, args) => {
+        const { query = '', limit = MAX_SEARCH_RESULTS } = args || {};
+        const tools = Tool.getOnDemandTools(session);
+        const q = String(query || '').trim().toLowerCase();
+        const matched = q
+            ? tools.filter(t =>
+                t.function.name.toLowerCase().includes(q) ||
+                t.function.description.toLowerCase().includes(q))
+            : tools;
+        const n = Math.max(1, Math.min(20, parseInt(limit, 10) || MAX_SEARCH_RESULTS));
+        const list = matched.slice(0, n);
+        if (list.length === 0) {
+            return q
+                ? `没有找到与「${query}」匹配的工具`
+                : '当前没有其他可用工具';
+        }
+        return list.map((t, i) => {
+            return `${i + 1}. ${t.function.name}\n描述：${t.function.description}\n参数（JSON Schema）：\n${JSON.stringify(t.function.parameters, null, 2)}\n调用方式：使用 call_tool，参数为 {"name": "${t.function.name}", "arguments": {…}}`;
+        }).join('\n\n') + `\n\n共匹配 ${matched.length} 个，已返回 ${list.length} 个。`;
+    };
+
+    // 统一执行入口：调用任意已开启工具（含未注入 schema 的按需工具）
+    const callTool = new Tool({
+        type: "function",
+        function: {
+            name: "call_tool",
+            description: `执行指定名称的工具并返回结果。可调用当前会话所有已开启的工具，包括未直接在函数列表中提供的工具；工具参数格式请先用 search_tools 查询。`,
+            parameters: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string",
+                        description: "要执行的工具名称"
+                    },
+                    arguments: {
+                        type: "object",
+                        description: "传给该工具的参数对象，字段与 search_tools 返回的参数说明一致"
+                    }
+                },
+                required: ["name"]
+            }
+        }
+    });
+    callTool.sensitive = true; // 可触发任意工具（含发消息/封禁等敏感操作），调用会显著记录
+    callTool.solve = async (ctx, msg, session: Session, args) => {
+        const { name, arguments: rawArgs } = args || {};
+        const toolName = String(name || '').trim();
+        if (!toolName) return 'call_tool 缺少工具名 name';
+        if (!Object.prototype.hasOwnProperty.call(toolMap, toolName)) {
+            return `工具 ${toolName} 不存在，可先调用 search_tools 查看可用工具`;
+        }
+        if (!session.toolState?.[toolName]) {
+            return `工具 ${toolName} 未开启，无法调用`;
+        }
+
+        let toolArgs = rawArgs || {};
+        // 兼容提示词工程模式下 arguments 以 JSON 字符串传入
+        if (typeof toolArgs === 'string') {
+            try {
+                toolArgs = JSON.parse(toolArgs);
+            } catch (e) {
+                return `call_tool 参数解析失败: ${e instanceof Error ? e.message : String(e)}`;
+            }
+        }
+
+        const tool = toolMap[toolName];
+        if (tool.sessionType !== "any" && tool.sessionType !== session.sessionType) {
+            return `工具 ${toolName} 不适用于当前会话类型`;
+        }
+        for (const key of (tool.toolInfo.function.parameters.required || [])) {
+            if (!Object.prototype.hasOwnProperty.call(toolArgs, key)) {
+                return `调用工具 ${toolName} 缺少必需参数 ${key}`;
+            }
+        }
+        const validateError = Tool.validateArgs(tool, toolArgs);
+        if (validateError) {
+            return `调用工具 ${toolName} 参数错误: ${validateError}`;
+        }
+
+        const time = Date.now();
+        try {
+            const content = await withTimeout(() => tool.solve(ctx, msg, session, toolArgs), Config.base.TIMEOUT);
+            Logger.info(`[call_tool] ${toolName} 执行耗时 ${Date.now() - time}ms${tool.sensitive ? ' [敏感]' : ''}`);
+            return `工具 ${toolName} 返回：\n${content}`;
+        } catch (e) {
+            Logger.error(`[call_tool] ${toolName} 执行失败: ${e instanceof Error ? e.message : String(e)}`);
+            return `工具 ${toolName} 执行失败: ${e instanceof Error ? e.message : String(e)}`;
+        }
+    };
+}

--- a/src/tool/tools/tool_dispatch.ts
+++ b/src/tool/tools/tool_dispatch.ts
@@ -16,17 +16,21 @@ export function registerDispatchTools() {
         type: "function",
         function: {
             name: "search_tools",
-            description: `搜索当前会话可用的工具，返回工具的名称、描述与完整参数说明。需要调用未直接在函数列表中提供的工具时，先调用本工具获取参数格式，再通过 call_tool 执行。query 留空时返回全部可用工具的简表。`,
+            description: `查看/搜索当前会话可用的工具。不传参数：返回全部可用工具的名字列表；指定 name：返回该工具的完整参数说明；指定 query：按关键词搜索匹配工具并返回完整参数说明。需要调用未直接在函数列表中提供的工具时，先通过本工具获取参数格式，再通过 call_tool 执行。`,
             parameters: {
                 type: "object",
                 properties: {
                     query: {
                         type: "string",
-                        description: "搜索关键词，匹配工具名称或描述；留空返回全部可用工具简表"
+                        description: "搜索关键词，匹配工具名称或描述；与 name 同时给出时以 name 优先"
+                    },
+                    name: {
+                        type: "string",
+                        description: "指定工具名，返回该工具的完整参数说明"
                     },
                     limit: {
                         type: "integer",
-                        description: "最多返回的工具数，默认 8，最大 20"
+                        description: "query 搜索时最多返回的工具数，默认 8，最大 20"
                     }
                 },
                 required: []
@@ -34,10 +38,25 @@ export function registerDispatchTools() {
         }
     });
     searchTool.solve = async (_ctx, _msg, session: Session, args) => {
-        const { query = '', limit = MAX_SEARCH_RESULTS } = args || {};
-        const tools = Tool.getOnDemandTools(session);
+        const { query = '', name = '', limit = MAX_SEARCH_RESULTS } = args || {};
+        const tools = Tool.getAvailableTools(session);
+        const toolName = String(name || '').trim();
+
+        // 指定工具名：返回该工具的完整详情
+        if (toolName) {
+            const target = tools.find(t => t.function.name === toolName);
+            if (!target) return `工具 ${toolName} 不存在或未开启；可调用 search_tools（不传参数）查看全部工具名`;
+            return formatToolDetail(target, 1);
+        }
+
+        // 不传参数：返回全部工具名字列表（紧凑），详情按需查询
+        if (!String(query || '').trim()) {
+            if (tools.length === 0) return '当前没有可用工具';
+            return `可用工具（共 ${tools.length} 个）：\n${tools.map((t, i) => `${i + 1}. ${t.function.name}`).join('\n')}\n查看某个工具的详情：调用 search_tools 并指定 name=工具名`;
+        }
+
+        // 关键词搜索：分词匹配，返回匹配工具的完整详情
         const q = String(query || '').trim().toLowerCase();
-        // 按空格分词，任一关键词命中即匹配（如 “新闻 搜索” 可命中 web_search），并按命中数排序
         const keywords = q.split(/\s+/).filter(Boolean);
         const matched = keywords.length === 0
             ? tools
@@ -48,13 +67,9 @@ export function registerDispatchTools() {
         const n = Math.max(1, Math.min(20, parseInt(limit, 10) || MAX_SEARCH_RESULTS));
         const list = matched.slice(0, n);
         if (list.length === 0) {
-            return q
-                ? `没有找到与「${query}」匹配的工具`
-                : '当前没有其他可用工具';
+            return `没有找到与「${query}」匹配的工具`;
         }
-        return list.map((t, i) => {
-            return `${i + 1}. ${t.function.name}\n描述：${t.function.description}\n参数（JSON Schema）：\n${JSON.stringify(t.function.parameters, null, 2)}\n调用方式：使用 call_tool，参数为 {"name": "${t.function.name}", "arguments": {…}}`;
-        }).join('\n\n') + `\n\n共匹配 ${matched.length} 个，已返回 ${list.length} 个。`;
+        return list.map((t, i) => formatToolDetail(t, i + 1)).join('\n\n') + `\n\n共匹配 ${matched.length} 个，已返回 ${list.length} 个。`;
     };
 
     // 统一执行入口：调用任意已开启工具（含未注入 schema 的按需工具）
@@ -125,6 +140,11 @@ export function registerDispatchTools() {
             return `工具 ${toolName} 执行失败: ${e instanceof Error ? e.message : String(e)}`;
         }
     };
+}
+
+/** 输出单个工具的完整详情（名称/描述/参数 schema/调用方式） */
+function formatToolDetail(tool: ToolInfo, index: number): string {
+    return `${index}. ${tool.function.name}\n描述：${tool.function.description}\n参数（JSON Schema）：\n${JSON.stringify(tool.function.parameters, null, 2)}\n调用方式：使用 call_tool，参数为 {"name": "${tool.function.name}", "arguments": {…}}`;
 }
 
 /** 统计工具被命中的关键词数（匹配名称或描述） */

--- a/src/tool/tools/tool_dispatch.ts
+++ b/src/tool/tools/tool_dispatch.ts
@@ -6,6 +6,7 @@ import Logger from "../../logger";
 import { Session } from "../../session/session";
 import { withTimeout } from "../../utils/utils";
 import Tool, { toolMap } from "../tool";
+import { ToolInfo } from "../types";
 
 const MAX_SEARCH_RESULTS = 8; // search_tools 单次返回工具数上限
 
@@ -36,11 +37,14 @@ export function registerDispatchTools() {
         const { query = '', limit = MAX_SEARCH_RESULTS } = args || {};
         const tools = Tool.getOnDemandTools(session);
         const q = String(query || '').trim().toLowerCase();
-        const matched = q
-            ? tools.filter(t =>
-                t.function.name.toLowerCase().includes(q) ||
-                t.function.description.toLowerCase().includes(q))
-            : tools;
+        // 按空格分词，任一关键词命中即匹配（如 “新闻 搜索” 可命中 web_search），并按命中数排序
+        const keywords = q.split(/\s+/).filter(Boolean);
+        const matched = keywords.length === 0
+            ? tools
+            : tools.map(t => ({ tool: t, hits: countKeywordHits(t, keywords) }))
+                .filter(x => x.hits > 0)
+                .sort((a, b) => b.hits - a.hits)
+                .map(x => x.tool);
         const n = Math.max(1, Math.min(20, parseInt(limit, 10) || MAX_SEARCH_RESULTS));
         const list = matched.slice(0, n);
         if (list.length === 0) {
@@ -121,4 +125,10 @@ export function registerDispatchTools() {
             return `工具 ${toolName} 执行失败: ${e instanceof Error ? e.message : String(e)}`;
         }
     };
+}
+
+/** 统计工具被命中的关键词数（匹配名称或描述） */
+function countKeywordHits(tool: ToolInfo, keywords: string[]): number {
+    const haystack = `${tool.function.name} ${tool.function.description}`.toLowerCase();
+    return keywords.reduce((acc, kw) => acc + (haystack.includes(kw) ? 1 : 0), 0);
 }


### PR DESCRIPTION
## 背景
函数列表全量注入导致 token 浪费：约 53 个工具定义占 2 万字符（PE 模式 system prompt 实测 19999 字符）。采用 Anthropic Tool Search 的思路，改为「核心常驻 + 按需加载」。

## 改动
- 新增常驻核心工具集（始终注入 schema）：`search_tools`（发现）、`call_tool`（执行）、`use_skill`、`run_command`、`get_cmd_help`、`get_time`
- 其余工具（发送消息/搜索/记忆/图片/封禁/论坛等 40+ 个）不再全量注入，由 `search_tools` 按关键词发现（返回完整参数 schema），再通过 `call_tool` 统一执行
- `search_tools` 支持三种用法：不传参列出全部工具名；`name=` 查看指定工具详情；`query=` 多关键词分词搜索（任一命中，按命中数排序）
- `call_tool` 复用统一执行路径：参数校验、超时、敏感标记、日志审计
- PE 模式 system prompt 同步改造：核心工具完整模板 + 其他工具一行摘要（名称+描述），详细参数按需 `search_tools` 获取
- 非核心工具仍可在 `.ai tool on/off/call` 中正常开关与试用

## 效果（实测）
- system prompt：19999 → 2806 字符（-86%）
- 函数调用模式：AI 可直接使用核心工具（get_time）；需要非核心工具时自动 search_tools → call_tool（实测：搜索新闻 → 发现 web_search → 执行 → 无结果重试 → 基于结果回复）
- `search_tools` 不传参返回全部 56 个工具名，`name=` 返回指定工具完整参数说明
- 日志审计：call_tool 标记 [敏感]，记录子工具名与耗时

改动文件：src/tool/tool.ts、src/tool/tools/init.ts、src/tool/tools/tool_dispatch.ts（新增）