### PR TITLE
docs: 4.13.3 发布准备（版本号/更新日志/README 工具表与文档同步）

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - 让你的骰娘活起来
 
 ![License](https://img.shields.io/badge/License-MIT-blue)
-![Version](https://img.shields.io/badge/Version-4.13.2-green)
+![Version](https://img.shields.io/badge/Version-4.13.3-green)
 
 ## 快速开始
 
@@ -420,10 +420,12 @@ max_tokens = 2048
 | 消息 | `send_msg`、`get_msg`、`delete_msg`、`send_forward_msg`、`get_context` |
 | 定时 | `get_time`、`set_timer`、`show_timer_list`、`cancel_timer` |
 | 触发 | `set_trigger_condition` |
+| 指令 | `run_command`（列出/调用海豹指令）、`get_cmd_help`（查看指令帮助） |
+| 工具调度 | `search_tools`（按需搜索工具）、`call_tool`（统一执行任意工具） |
 | 语音 | `record`、`text_to_sound` |
 | 网页 | `web_search`、`web_read` |
-| TRPG | `roll_check`、`san_check`、`jrrp`、`modu_roll`、`modu_search`、`draw_deck` |
-| 属性 | `attr_show`、`attr_get`、`attr_set` |
+| TRPG | `draw_deck` |
+| 属性 | `attr_get`、`attr_set` |
 | 图片 | `image_to_text`、`text_to_image`、`meme_list`、`get_meme_info`、`meme_generator`、`render_markdown`、`render_html` |
 | QQ 管理 | `ban`、`whole_ban`、`get_ban_list`、`rename`、`group_sign` |
 | 群资料 | `get_list`、`get_group_member_list`、`search_chat`、`search_common_group`、`get_person_info` |
@@ -433,9 +435,11 @@ max_tokens = 2048
 | 论坛 | `forum_get_posts`、`forum_get_post_detail`、`forum_search`、`forum_create_post`、`forum_manage_comment`、`forum_get_activity`、`forum_manage_post` |
 | MCP / 技能 | `<服务器名>_<工具名>`（MCP 工具）、`use_skill`（技能） |
 
+> 指令类技能（今日人品、COC 模组抽取/搜索、属性展示、属性检定、san 检定等）通过 `use_skill` 按需获取内容，内部统一使用 `run_command` 调用海豹指令，对应指令需加入「可调用指令白名单」。
+
 > 依赖说明：ob11 相关工具需要安装 [ob11 网络连接依赖](https://raw.githubusercontent.com/error2913/sealdice-plugin-ob11-net-connection/refs/heads/main/dist/ob11%E7%BD%91%E7%BB%9C%E8%BF%9E%E6%8E%A5%E4%BE%9D%E8%B5%96.js) 或 [http 依赖插件](https://github.com/error2913/sealdice-js/blob/main/HTTP%E4%BE%9D%E8%B5%96.js)；`text_to_sound` 预设音色需要支持 AI 语音的协议端，自定义音色需要 AITTS 依赖与 ffmpeg；`text_to_image` 需要 AIDrawing 依赖；`music_play` 需要协议端配置音卡签名；`render_markdown` / `render_html` 需要配置 md 和 html 图片渲染后端。
 
-> 依赖海豹内置指令的工具（如 `attr_show`、`roll_check`、`draw_deck`、`send_msg` 等）需要会话中先出现过指令消息（如先使用 `.r`），否则工具会提示"请先使用 .r 指令"。
+> 依赖海豹内置指令的工具（如 `draw_deck`、`send_msg` 等）需要会话中先出现过指令消息（如先使用 `.r`），否则工具会提示"请先使用 .r 指令"。
 
 ---
 

--- a/docs/01-项目概览.md
+++ b/docs/01-项目概览.md
@@ -29,9 +29,9 @@ AI 骰娘4(`aiplugin4`)是运行在 SealDice 上的 JavaScript 插件,为骰娘�
 
 ## 版本信息
 
-- `src/config/static_config.ts` 中 `VERSION = "4.13.2"`,作者 `baiyu&错误`,插件名 `aiplugin4`。
+- `src/config/static_config.ts` 中 `VERSION = "4.13.3"`,作者 `baiyu&错误`,插件名 `aiplugin4`。
 - 开发遵循「分支 + squash PR」流程(见 [07-开发指南](07-开发指南.md));近期工作围绕:模型配置 TOML 化、Provider 统一请求(超时/重试/用量上报)、智能体编排重构、MCP/技能、日志治理、消息管线、配套后端独立仓库化等。
-- README 顶部徽章与 `VERSION` 保持一致（当前 4.13.2）(详见 [09-注意事项与常见问题](09-注意事项与常见问题.md))。
+- README 顶部徽章与 `VERSION` 保持一致（当前 4.13.3）(详见 [09-注意事项与常见问题](09-注意事项与常见问题.md))。
 
 ## 环境要求
 

--- a/docs/03-核心模块详解.md
+++ b/docs/03-核心模块详解.md
@@ -31,7 +31,7 @@
 
 ### static_config.ts(静态常量)
 
-- `VERSION`(当前 4.13.2)、`AUTHOR`、`NAME`、`STORAGE_VERSION`、`CONFIG_CACHE_TTL`、`CQ_TYPES_ALLOW`。
+- `VERSION`(当前 4.13.3)、`AUTHOR`、`NAME`、`STORAGE_VERSION`、`CONFIG_CACHE_TTL`、`CQ_TYPES_ALLOW`。
 - `PRIVILEGE_LEVEL_MAP`:master=100 / whitelist=70 / owner=60 / admin=50 / inviter=40 / user=0 / blacklist=-30。
 - `HELP_MAP`、`ALIAS_MAP`(命令别名表)、`FACE_MAP`(QQ 表情编号 → 名称)。
 - `PROVIDER_MAP`:10 家厂商的 OpenAI 兼容 base_url。

--- a/docs/09-注意事项与常见问题.md
+++ b/docs/09-注意事项与常见问题.md
@@ -14,7 +14,7 @@
 
 ## 代码中的已知不一致
 
-- `src/config/static_config.ts` 的 `VERSION` 与 `src/update.ts` 的 `updateInfo` 最新条目需保持一致（当前 4.13.2）；`checkUpdate` 按 `VERSION` 比较输出对应更新日志。
+- `src/config/static_config.ts` 的 `VERSION` 与 `src/update.ts` 的 `updateInfo` 最新条目需保持一致（当前 4.13.3）；`checkUpdate` 按 `VERSION` 比较输出对应更新日志。
 - `package.json` 的 `main`/`typings` 指向 `build/index.js`/`build/index.d.ts`,但实际构建产物是 `dist/aiplugin4.js`(esbuild),`build/` 目录是陈旧的 tsc 输出,与构建流程无关。
 - `engines.node >= 10` 是模板遗留,实际构建依赖 esbuild,建议使用较新 Node。
 - `sub_cmd/sample.ts` 与 `agent/agents/samples.ts` 是开发示例,未注册到运行时。

--- a/header.txt
+++ b/header.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AI骰娘4
 // @author       错误、白鱼
-// @version      4.13.2
+// @version      4.13.3
 // @description  适用于大部分OpenAI API兼容格式AI的模型插件，测试环境为 Deepseek AI (https://platform.deepseek.com/)，用于与 AI 进行对话，并根据特定关键词触发回复。使用.ai help查看使用方法。具体配置查看插件配置项。\nopenai标准下的function calling功能已进行适配，选用模型若不支持该功能，可以开启迁移到提示词工程的开关，即可使用调用函数功能。\n交流答疑QQ群：143412516
 // @timestamp    1733387279
 // 2024-12-05 16:27:59

--- a/sealpack/info.toml
+++ b/sealpack/info.toml
@@ -7,7 +7,7 @@ format_version = "1.0.0"
 [package]
 id = "error2913/aiplugin4"
 name = "AI骰娘4"
-version = "4.13.2"
+version = "4.13.3"
 authors = ["错误、白鱼"]
 license = "MIT"
 description = "适用于大部分 OpenAI API 兼容格式 AI 的 Sealdice 模型插件，支持对话、记忆、工具调用、MCP/Skills 等。"

--- a/src/config/static_config.ts
+++ b/src/config/static_config.ts
@@ -1,5 +1,5 @@
 // 静态常量：版本/作者/模型映射表/权限等级/别名/表情表等
-export const VERSION = "4.13.2";
+export const VERSION = "4.13.3";
 export const AUTHOR = "baiyu&错误";
 export const NAME = "aiplugin4";
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,15 @@
 // 版本更新日志（updateInfo），供启动时展示更新说明
 // 版本更新日志，格式为 "版本号": "更新内容"，版本号格式为 "x.y.z"，按照时间顺序从新到旧排列。
 export const updateInfo: { [version: string]: string } = {
+    "4.13.3": `## 新功能
+- 新增 run_command 工具：读取海豹扩展指令表列出可用指令（action=list 不含帮助），并可调用白名单内的海豹指令（action=call，开启「是否允许调用所有指令」后可调用任意指令）；配套 get_cmd_help 工具按名查看指令帮助
+- 新增「可调用指令白名单」「是否允许调用所有指令」配置（工具页签）；指令技能（今日人品/COC 模组/属性展示/检定/san检定）统一改为通过 run_command 调用
+- 工具按需加载：search_tools/call_tool/use_skill/run_command/get_cmd_help/get_time 常驻，其余工具按需搜索并统一执行，system prompt 从约 2 万字符降到约 2800 字符
+## 优化
+- 更新链接改为官方 GitHub Release；商店 README 移除开发章节，只保留用户文档
+## 修复
+- tsconfig 改用 bundler 解析模式，兼容 TypeScript 6+
+- 工具超长返回仅记录日志不发送，并分段打印`,
     "4.13.2": `## 新功能
 - 新增「是否开启图片模型」「是否开启嵌入模型」总开关（默认关闭，配置好对应模型后开启；关闭后图片识别、向量记忆的嵌入生成与检索不生效）
 ## 优化


### PR DESCRIPTION
## 版本推进 4.13.2 → 4.13.3
- `src/config/static_config.ts` 的 `VERSION`
- `header.txt` 的 `@version`
- `sealpack/info.toml` 的 `version`
- `src/update.ts` 新增 4.13.3 更新日志（run_command、工具按需加载、更新链接、tsconfig 修复等）

## 文档整理
- README 版本徽章更新；工具函数表修正：移除已删除的旧工具（roll_check/san_check/jrrp/modu_roll/modu_search/attr_show），补充新工具（run_command/get_cmd_help/search_tools/call_tool），并说明指令类技能经 use_skill + run_command 使用
- docs/01、03、09 的版本引用同步为 4.13.3

## 验证
- lint / tsc / build 通过；`node scripts/release-notes.js 4.13.3` 可正常提取更新日志