### PR TITLE
feat: 对外 API 暴露三种模型直接调用（chatMessages/imageToText/embed）

### DIFF
--- a/docs/07-开发指南.md
+++ b/docs/07-开发指南.md
@@ -109,6 +109,9 @@ registerSay();
 | `getAgent(name?)` | 获取智能体实例,`name` 缺省为默认智能体 `*` |
 | `getSession(agentName, sessionId)` | 获取指定智能体的会话 |
 | `chat(prompt, agentName?)` | 单轮对话:不经过会话上下文与工具,直接返回模型回复文本 |
+| `chatMessages(messages, agentName?)` | 对话:直接发送 OpenAI 风格 `messages` 数组到对话模型,返回回复文本 |
+| `imageToText(source, prompt?)` | 识图:对图片 id 或 http(s) 图片地址调用图片识别模型,返回描述文本 |
+| `embed(text)` | 嵌入:调用嵌入模型返回文本向量(未配置嵌入模型时返回空数组) |
 | `run(ctx, msg, options?)` | 在当前聊天中触发一次完整对话编排(上下文/工具/回复发送),等价于该会话收到一次触发 |
 | `registerTool(info, options?)` | 注册一个工具,供 AI 通过函数调用/提示词工程使用;同名内置工具不可覆盖,成功返回 true |
 
@@ -122,6 +125,18 @@ if (!api) return; // 本插件未安装
 
 // 单轮对话,直接拿回复文本
 const reply = await api.chat('用一句话介绍你自己');
+
+// 对话:构建 messages 数组直接调用模型
+const reply2 = await api.chatMessages([
+    { role: 'system', content: '你是翻译助手' },
+    { role: 'user', content: '翻译：hello' }
+]);
+
+// 识图:传图片 id 或 URL,返回描述文本
+const desc = await api.imageToText('https://example.com/a.png', '画面里有什么？');
+
+// 嵌入:返回文本向量
+const vec = await api.embed('要检索的文本');
 
 // 指定智能体(如 KP 插件驱动 kp_agent)
 const hint = await api.chat('根据当前剧情给主持人的私聊提示', 'kp_agent');

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -70,6 +70,14 @@ export default class Agent {
         return content;
     }
 
+    /** 直接发送自定义 messages（OpenAI 风格数组）到对话模型，返回回复文本；供外部插件构建消息后调用 */
+    async chatMessages(messages: { role: string, content: string }[]): Promise<string> {
+        const model = Model.getChatModel(this.use) as ChatModel;
+        if (!model) return '';
+        const { content } = await streamService.sendChatRequest(messages, [], 'none');
+        return content;
+    }
+
     /**
      * 标准智能体编排：构建消息 → 请求模型 → 执行工具调用（函数调用/提示词工程）→ 回填上下文 →
      * 循环直到模型给出最终回复（带轮次上限），最后统一拆分并发送回复。

--- a/src/agent/api.ts
+++ b/src/agent/api.ts
@@ -1,6 +1,9 @@
 // 对外 API：把智能体暴露到 globalThis，供其他海豹插件调用
+import Config from "../config/config";
 import { NAME, VERSION } from "../config/static_config";
 import { logger } from "../logger";
+import Model from "../model/model";
+import Image from "../resource/image";
 import { Session } from "../session/session";
 import { SessionType } from "../session/types";
 import Tool, { toolMap } from "../tool/tool";
@@ -45,6 +48,12 @@ export interface AgentGlobalApi {
     getSession(agentName: string, sessionId: string): Session;
     /** 单轮对话：不经过会话上下文与工具，直接返回模型回复文本（无可用模型时返回空串） */
     chat(prompt: string, agentName?: string): Promise<string>;
+    /** 对话：直接发送 OpenAI 风格 messages 数组到对话模型，返回回复文本（无可用模型时返回空串） */
+    chatMessages(messages: { role: string, content: string }[], agentName?: string): Promise<string>;
+    /** 识图：对图片 id 或 http(s) 图片地址调用图片识别模型，返回描述文本；未开启图片模型/未配置模型/找不到图片时返回错误说明 */
+    imageToText(source: string, prompt?: string): Promise<string>;
+    /** 嵌入：调用嵌入模型返回文本向量；未配置嵌入模型时返回空数组 */
+    embed(text: string): Promise<number[]>;
     /** 在当前聊天中触发一次完整对话编排（上下文/工具/回复发送），等价于该会话收到一次触发 */
     run(ctx: seal.MsgContext, msg: seal.Message, options?: AgentRunOptions): Promise<void>;
     /** 注册一个工具，供 AI 通过函数调用/提示词工程使用；同名内置工具不可覆盖，成功返回 true */
@@ -62,6 +71,26 @@ export function registerAgentApi(): void {
         getAgent: (name?: string) => Agent.get(name || '*'),
         getSession: (agentName: string, sessionId: string) => Agent.get(agentName).sessionService.getSession(sessionId),
         chat: async (prompt: string, agentName?: string) => Agent.get(agentName || '*').chat(prompt),
+        chatMessages: async (messages: { role: string, content: string }[], agentName?: string) => Agent.get(agentName || '*').chatMessages(messages),
+        imageToText: async (source: string, prompt?: string) => {
+            if (!Config.image.IMAGE_MODEL_ENABLED) return '图片模型开关未开启';
+            if (!Model.getImageModel('image-understanding')) return '未找到支持 image-understanding 的图片模型';
+            let img = Image.get(source);
+            if (!img && /^https?:\/\//i.test(source)) {
+                img = Image.createUrlImage('', source);
+            }
+            if (!img) return `未找到图片 ${source}（支持图片 id 或 http(s) 图片地址）`;
+            await img.imageToText(prompt);
+            return img.description || `图片 ${source} 识别失败`;
+        },
+        embed: async (text: string) => {
+            const model = Model.getEmbeddingModel('text-embedding');
+            if (!model) {
+                logger.warning('外部调用 embed 失败：未找到嵌入模型');
+                return [];
+            }
+            return await model.callEmbedding(text);
+        },
         run: async (ctx: seal.MsgContext, msg: seal.Message, options: AgentRunOptions = {}) => {
             const agent = Agent.get(options.agentName || '*');
             const sessionId = ctx.isPrivate ? ctx.player.userId : ctx.group.groupId;


### PR DESCRIPTION
## 背景
外部插件此前只能通过 `chat(prompt)`（纯文本单轮）或 `run()`（完整编排，回复发进会话）与 aiplugin4 交互，无法直接构建消息调用模型，也拿不到识图/嵌入结果。

## 改动
`globalThis.aiplugin4` 新增三个方法：

- `chatMessages(messages, agentName?)`：传入 OpenAI 风格 `messages` 数组，直接调用对话模型并返回回复文本（`Agent` 类新增同名方法）
- `imageToText(source, prompt?)`：对图片 id 或 http(s) 图片地址调用图片识别模型（`image-understanding`），返回描述文本；图片模型开关未开/未配置模型/找不到图片时返回明确错误说明
- `embed(text)`：调用嵌入模型（`text-embedding`）返回文本向量；未配置嵌入模型时返回空数组

## 文档
- docs/07-开发指南.md「为其他插件提供 API」表格与示例同步补充三个方法

## 验证
- lint / tsc / build 通过