### PR TITLE
fix: 补齐 seal.d.ts 类型（group 参数/Promise solve），onMessageSend 补 flag 参数

### DIFF
--- a/src/agent/api.ts
+++ b/src/agent/api.ts
@@ -93,7 +93,7 @@ export function registerAgentApi(): void {
         },
         run: async (ctx: seal.MsgContext, msg: seal.Message, options: AgentRunOptions = {}) => {
             const agent = Agent.get(options.agentName || '*');
-            const sessionId = ctx.isPrivate ? ctx.player.userId : ctx.group.groupId;
+            const sessionId = ctx.isPrivate ? ctx.player!.userId : ctx.group!.groupId;
             const session = agent.sessionService.getSession(sessionId);
             await session.chat(ctx, msg, options.reason || '外部插件调用', options.toolChoice);
         },

--- a/src/cmd/root_cmd.ts
+++ b/src/cmd/root_cmd.ts
@@ -96,8 +96,8 @@ export function registerCmd() {
 
             const subCmd = aliasToCmd(cmdArgs.getArgN(1));
             if (Object.prototype.hasOwnProperty.call(SubCmd.map, aliasToCmd(subCmd))) {
-                const uid = ctx.player.userId;
-                const gid = ctx.group.groupId;
+                const uid = ctx.player!.userId;
+                const gid = ctx.group!.groupId;
                 const epId = ctx.endPoint.userId;
                 const sid = ctx.isPrivate ? uid : gid;
 

--- a/src/cmd/sub_cmd/block.ts
+++ b/src/cmd/sub_cmd/block.ts
@@ -20,7 +20,7 @@ export function registerCmdBlock() {
         const { ctx, msg, cmdArgs, epId, ret } = scc;
 
         const mctx = seal.getCtxProxyFirst(ctx, cmdArgs);
-        const muid = cmdArgs.amIBeMentionedFirst ? epId : mctx.player.userId;
+        const muid = cmdArgs.amIBeMentionedFirst ? epId : mctx.player!.userId;
 
         const val2 = cmdArgs.getArgN(2);
         switch (aliasToCmd(val2)) {

--- a/src/cmd/sub_cmd/ignore.ts
+++ b/src/cmd/sub_cmd/ignore.ts
@@ -23,7 +23,7 @@ export function registerCmdIgnore() {
         }
 
         const mctx = seal.getCtxProxyFirst(ctx, cmdArgs);
-        const muid = cmdArgs.amIBeMentionedFirst ? epId : mctx.player.userId;
+        const muid = cmdArgs.amIBeMentionedFirst ? epId : mctx.player!.userId;
 
         const val2 = cmdArgs.getArgN(2);
         switch (aliasToCmd(val2)) {

--- a/src/cmd/sub_cmd/memory.ts
+++ b/src/cmd/sub_cmd/memory.ts
@@ -53,7 +53,7 @@ export function registerCmdMemory() {
         const { ctx, msg, cmdArgs, epId, session, page, ret  } = scc;
 
         const sessionCtx = seal.getCtxProxyFirst(ctx, cmdArgs);
-        const targetUserId = sessionCtx.player.userId;
+        const targetUserId = sessionCtx.player!.userId;
 
         const targetSession = getSession(targetUserId);
         const val2 = cmdArgs.getArgN(2);
@@ -110,8 +110,8 @@ export function registerCmdMemory() {
                         targetSession.memory.deleteMemory(idList, kw);
                         seal.replyToSender(ctx, msg, targetSession.memory.getLatestMemoryListText({
                             isPrivate: true,
-                            id: sessionCtx.player.userId,
-                            name: sessionCtx.player.name
+                            id: sessionCtx.player!.userId,
+                            name: sessionCtx.player!.name
                         }, page) || '记忆已全部清除');
                         targetSession.save();
                         return ret;
@@ -119,8 +119,8 @@ export function registerCmdMemory() {
                     case 'list': {
                         seal.replyToSender(ctx, msg, targetSession.memory.getLatestMemoryListText({
                             isPrivate: true,
-                            id: sessionCtx.player.userId,
-                            name: sessionCtx.player.name
+                            id: sessionCtx.player!.userId,
+                            name: sessionCtx.player!.name
                         }, page) || '无记忆');
                         return ret;
                     }
@@ -184,8 +184,8 @@ export function registerCmdMemory() {
                         session.memory.deleteMemory(idList, kw);
                         seal.replyToSender(ctx, msg, session.memory.getLatestMemoryListText({
                             isPrivate: false,
-                            id: ctx.group.groupId,
-                            name: ctx.group.groupName
+                            id: ctx.group!.groupId,
+                            name: ctx.group!.groupName
                         }, page) || '记忆已全部清除');
                         session.save();
                         return ret;
@@ -193,8 +193,8 @@ export function registerCmdMemory() {
                     case 'list': {
                         seal.replyToSender(ctx, msg, session.memory.getLatestMemoryListText({
                             isPrivate: false,
-                            id: ctx.group.groupId,
-                            name: ctx.group.groupName
+                            id: ctx.group!.groupId,
+                            name: ctx.group!.groupName
                         }, page) || '无记忆');
                         return ret;
                     }

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -99,7 +99,7 @@ export class Context {
         // 自动改名：按 autoNameMod 设置，在用户首次出现时更新上下文中的名字
         if (this.autoNameMod > 0) {
             try {
-                await this.updateName(ctx.endPoint.userId, ctx.group.groupId, userId);
+                await this.updateName(ctx.endPoint.userId, ctx.group!.groupId, userId);
             } catch (e) {
                 Logger.warning('自动改名失败: ' + (e instanceof Error ? e.message : String(e)));
             }
@@ -229,7 +229,7 @@ export class Context {
         const match = name.match(/^<([^>]+?)>(?:[\(（]\d+[\)）])?$|(.+?)[\(（]\d+[\)）]$/);
         if (match) name = match[1] || match[2];
 
-        if (name === ctx.player.name) return returnUserId(ctx.player.userId);
+        if (name === ctx.player!.name) return returnUserId(ctx.player!.userId);
         if (name === seal.formatTmpl(ctx, "核心:骰子名字")) return returnUserId(ctx.endPoint.userId);
 
         // 在上下文和记忆中查找用户
@@ -243,7 +243,7 @@ export class Context {
         // 在群成员列表、好友列表中查找用户
         if (netExists()) {
             const epId = ctx.endPoint.userId;
-            const gid = ctx.group.groupId;
+            const gid = ctx.group!.groupId;
 
             if (!ctx.isPrivate) {
                 const groupMemberList = await getGroupMemberList(epId, gid.replace(/^.+:/, ''));
@@ -262,7 +262,7 @@ export class Context {
             }
         }
 
-        if (name.length > 4 && levenshteinDistance(name, ctx.player.name) <= 2) return returnUserId(ctx.player.userId);
+        if (name.length > 4 && levenshteinDistance(name, ctx.player!.name) <= 2) return returnUserId(ctx.player!.userId);
 
         Logger.warning(`未找到用户<${name}>`);
         return '';
@@ -331,7 +331,7 @@ export class Context {
         const match = groupName.match(/^<([^>]+?)>(?:[\(（]\d+[\)）])?$|(.+?)[\(（]\d+[\)）]$/);
         if (match) groupName = match[1] || match[2];
 
-        if (groupName === ctx.group.groupName) return ctx.group.groupId;
+        if (groupName === ctx.group!.groupName) return ctx.group!.groupId;
 
         // 在记忆中查找群聊
         for (const groupId of MemoryService.getItemsFromRelatedMemories(this.session, 'groups')) {
@@ -350,7 +350,7 @@ export class Context {
             }
         }
 
-        if (groupName.length > 4 && levenshteinDistance(groupName, ctx.group.groupName) <= 2) return ctx.group.groupId;
+        if (groupName.length > 4 && levenshteinDistance(groupName, ctx.group!.groupName) <= 2) return ctx.group!.groupId;
 
         Logger.warning(`未找到群聊<${groupName}>`);
         return '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ function main() {
 
     const msg = createMsg(event.isPrivate ? 'private' : 'group', event.senderId, event.groupId);
     msg.message = `[CQ:poke,qq=${event.targetId.replace(/^.+:/, '')}]`;
-    if (event.senderId === ctx.endPoint.userId) ext.onMessageSend(ctx, msg);
+    if (event.senderId === ctx.endPoint.userId) ext.onMessageSend(ctx, msg, '');
     else ext.onNotCommandReceived(ctx, msg);
   }
 

--- a/src/memory/memory.ts
+++ b/src/memory/memory.ts
@@ -199,8 +199,8 @@ export default class MemoryService {
         if (!ctx.isPrivate) {
             s += this.buildMemory({
                 isPrivate: false,
-                id: ctx.group.groupId,
-                name: ctx.group.groupName
+                id: ctx.group!.groupId,
+                name: ctx.group!.groupName
             }, await this.getTopScoreMemoryList(text, users, groups));
         }
         return s;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -15,14 +15,14 @@ export class MessagePipeline {
         const { TRIGGER_REGEX: triggerRegex, TRIGGER_CONDITION: triggerCondition } = Config.trigger;
 
         // 黑名单用户/群的消息不接收不处理
-        const uid = ctx.player.userId;
+        const uid = ctx.player!.userId;
         const blockReason = BlockManager.checkBlock(uid);
         if (blockReason) {
             logger.info(`用户<${uid}>在黑名单中，原因: ${blockReason}，忽略消息`);
             return;
         }
         if (!ctx.isPrivate) {
-            const gid = ctx.group.groupId;
+            const gid = ctx.group!.groupId;
             const groupBlockReason = BlockManager.checkBlock(gid);
             if (groupBlockReason) {
                 logger.info(`群组<${gid}>在黑名单中，原因: ${groupBlockReason}，忽略消息`);
@@ -34,7 +34,7 @@ export class MessagePipeline {
             return;
         }
 
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
         const sid = ctx.isPrivate ? uid : gid;
         const session = getSession(sid);
 
@@ -139,8 +139,8 @@ export class MessagePipeline {
         const { RECEIVE_CMD: allcmd } = Config.received;
         if (!allcmd) return;
 
-        const uid = ctx.player.userId;
-        const gid = ctx.group.groupId;
+        const uid = ctx.player!.userId;
+        const gid = ctx.group!.groupId;
         const sid = ctx.isPrivate ? uid : gid;
         const session = getSession(sid);
 
@@ -160,8 +160,8 @@ export class MessagePipeline {
 
     /** 机器人自身发送的消息：转发给监听工具，并按配置决定是否记录上下文 */
     static handleBotMessage(ctx: seal.MsgContext, msg: seal.Message): void {
-        const uid = ctx.player.userId;
-        const gid = ctx.group.groupId;
+        const uid = ctx.player!.userId;
+        const gid = ctx.group!.groupId;
         const sid = ctx.isPrivate ? uid : gid;
         const session = getSession(sid);
 

--- a/src/prompt/builder.ts
+++ b/src/prompt/builder.ts
@@ -41,7 +41,7 @@ export async function buildSystemPromptContent(
             const u = User.get(lastItem.userId);
             ui = { isPrivate: true, id: lastItem.userId, name: u.userName || lastItem.userId };
         }
-        gi = { isPrivate: false, id: ctx.group.groupId, name: ctx.group.groupName };
+        gi = { isPrivate: false, id: ctx.group!.groupId, name: ctx.group!.groupName };
     }
 
     // 记忆段：长期记忆 + 总结记忆 + 知识库（统一由 MemoryManager 按开关构建）
@@ -56,8 +56,8 @@ export async function buildSystemPromptContent(
         instruction: roleSetting,
         platform: ctx.endPoint.platform,
         sessionType: ctx.isPrivate ? 'private' : 'group',
-        sessionName: ctx.isPrivate ? ctx.player.name : ctx.group.groupName,
-        sessionId: ctx.isPrivate ? ctx.player.userId : ctx.group.groupId,
+        sessionName: ctx.isPrivate ? ctx.player!.name : ctx.group!.groupName,
+        sessionId: ctx.isPrivate ? ctx.player!.userId : ctx.group!.groupId,
         RECEIVE_IMAGE,
         LOCAL_IMAGES: localImages,
         LOCAL_AUDIOS: localAudios,

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -272,7 +272,7 @@ export class Session {
     async handleReceipt(ctx: seal.MsgContext, msg: seal.Message, messageArray: MessageSegment[]) {
         this.lastCtx = ctx;
         const { content } = await transformArrayToContent(ctx, messageArray);
-        await this.context.addUserMessage(ctx, content, ctx.player.userId, transformMsgId(msg.rawId));
+        await this.context.addUserMessage(ctx, content, ctx.player!.userId, transformMsgId(msg.rawId));
     }
 
     async reply(ctx: seal.MsgContext, msg: seal.Message, contextArray: string[], replyArray: string[], _images: Image[], options: { withSegmentDelay?: boolean } = {}) {

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -67,8 +67,8 @@ export class TimerManager {
     }
 
     static addTargetTimer(ctx: seal.MsgContext, session: Session, target: number, content: string) {
-        const uid = ctx.player.userId;
-        const gid = ctx.group.groupId;
+        const uid = ctx.player!.userId;
+        const gid = ctx.group!.groupId;
         const sessionId = ctx.isPrivate ? uid : gid;
         const timer = new TimerInfo();
         timer.sid = sessionId;
@@ -92,8 +92,8 @@ export class TimerManager {
     }
 
     static addIntervalTimer(ctx: seal.MsgContext, session: Session, interval: number, count: number, content: string) {
-        const uid = ctx.player.userId;
-        const gid = ctx.group.groupId;
+        const uid = ctx.player!.userId;
+        const gid = ctx.group!.groupId;
         const sessionId = ctx.isPrivate ? uid : gid;
         const timer = new TimerInfo();
         timer.sid = sessionId;
@@ -120,8 +120,8 @@ export class TimerManager {
     }
 
     static addActiveTimeTimer(ctx: seal.MsgContext, session: Session, target: number) {
-        const uid = ctx.player.userId;
-        const gid = ctx.group.groupId;
+        const uid = ctx.player!.userId;
+        const gid = ctx.group!.groupId;
         const sessionId = ctx.isPrivate ? uid : gid;
         const timer = new TimerInfo();
         timer.sid = sessionId;

--- a/src/tool/tool.ts
+++ b/src/tool/tool.ts
@@ -87,8 +87,8 @@ export default class Tool {
         cmdArgs.rawText = `.${cmdArgs.command} ${cmdArgs.rawArgs} ${at.map(item => `[CQ:at,qq=${item.userId.replace(/^.+:/, '')}]`).join(' ')}`;
 
         const ext = seal.ext.find(eci.extName);
-        if (!Object.prototype.hasOwnProperty.call(ext.cmdMap, eci.cmd)) {
-            Logger.warning(`扩展${eci.extName}中未找到指令:${eci.cmd}`);
+        if (!ext || !Object.prototype.hasOwnProperty.call(ext.cmdMap, eci.cmd)) {
+            Logger.warning(`扩展${eci.extName}未找到或缺少指令:${eci.cmd}`);
             return ['', false];
         }
 

--- a/src/tool/tools/ob11.ts/tool_ban.ts
+++ b/src/tool/tools/ob11.ts/tool_ban.ts
@@ -34,7 +34,7 @@ export function registerBan() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
         const ui = await session.context.findUser(ctx, name);
 
         if (ui === null) return `未找到<${name}>`;
@@ -76,7 +76,7 @@ export function registerBan() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         await setGroupWholeBan(epId, gid.replace(/^.+:/, ''), enable);
         return `已${enable ? '开启' : '关闭'}全员禁言`;
@@ -100,7 +100,7 @@ export function registerBan() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const groupShutList = await getGroupShutList(epId, gid.replace(/^.+:/, ''));
         if (!groupShutList || !Array.isArray(groupShutList)) return `获取禁言列表失败`;

--- a/src/tool/tools/ob11.ts/tool_essence_msg.ts
+++ b/src/tool/tools/ob11.ts/tool_essence_msg.ts
@@ -29,7 +29,7 @@ export function registerEssenceMsg() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const memberInfo = await getGroupMemberInfo(epId, gid.replace(/^.+:/, ''), epId.replace(/^.+:/, ''));
         if (!memberInfo) return `获取权限信息失败`;
@@ -60,7 +60,7 @@ export function registerEssenceMsg() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const essenceMsgList = await getEssenceMsgList(epId, gid.replace(/^.+:/, ''));
         if (!essenceMsgList || !Array.isArray(essenceMsgList)) return `获取群 ${gid} 精华消息列表失败`;
@@ -127,7 +127,7 @@ export function registerEssenceMsg() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const memberInfo = await getGroupMemberInfo(epId, gid.replace(/^.+:/, ''), epId.replace(/^.+:/, ''));
         if (!memberInfo) return `获取权限信息失败`;

--- a/src/tool/tools/ob11.ts/tool_group_sign.ts
+++ b/src/tool/tools/ob11.ts/tool_group_sign.ts
@@ -25,7 +25,7 @@ export function registerGroupSign() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         await sendGroupSign(epId, gid.replace(/^.+:/, ''));
         return `已发送群打卡`;

--- a/src/tool/tools/ob11.ts/tool_qq_list.ts
+++ b/src/tool/tools/ob11.ts/tool_qq_list.ts
@@ -76,7 +76,7 @@ export function registerQQList() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const groupMemberList = await getGroupMemberList(epId, gid.replace(/^.+:/, ''));
         if (!groupMemberList || !Array.isArray(groupMemberList)) return `获取群聊成员列表失败`;

--- a/src/tool/tools/ob11.ts/tool_rename.ts
+++ b/src/tool/tools/ob11.ts/tool_rename.ts
@@ -34,7 +34,7 @@ export function registerRename() {
 
         if (netExists()) {
             const epId = ctx.endPoint.userId;
-            const gid = ctx.group.groupId;
+            const gid = ctx.group!.groupId;
 
             const memberInfo = await getGroupMemberInfo(epId, gid.replace(/^.+:/, ''), epId.replace(/^.+:/, ''));
             if (!memberInfo) return `获取权限信息失败`;
@@ -44,14 +44,14 @@ export function registerRename() {
         const ui = await session.context.findUser(ctx, name);
         if (ui === null) return `未找到<${name}>`;
 
-        ({ ctx, msg } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group.groupId));
+        ({ ctx, msg } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group!.groupId));
 
         try {
             seal.setPlayerGroupCard(ctx, new_name);
             if (session.context.autoNameMod === 2) {
-                ctx.player.name = new_name;
+                ctx.player!.name = new_name;
             }
-            seal.replyToSender(ctx, msg, `已将<${ctx.player.name}>的群名片设置为<${new_name}>`);
+            seal.replyToSender(ctx, msg, `已将<${ctx.player!.name}>的群名片设置为<${new_name}>`);
             return '设置成功';
         } catch (e) {
             logger.error(e);

--- a/src/tool/tools/seal.ts/tool_attr.ts
+++ b/src/tool/tools/seal.ts/tool_attr.ts
@@ -31,7 +31,7 @@ export function registerAttrSeal() {
         const ui = await session.context.findUser(ctx, name);
         if (ui === null) return `未找到<${name}>`;
 
-        ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group.groupId));
+        ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group!.groupId));
 
         const value = seal.vars.intGet(ctx, attr)[0];
         return `${attr}: ${value}`;
@@ -64,7 +64,7 @@ export function registerAttrSeal() {
         const ui = await session.context.findUser(ctx, name);
         if (ui === null) return `未找到<${name}>`;
 
-        ({ ctx, msg } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group.groupId));
+        ({ ctx, msg } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ctx.group!.groupId));
 
         const [attr, expr] = expression.split('=');
         if (expr === undefined) return `修改失败，表达式 ${expression} 格式错误`;

--- a/src/tool/tools/tool_context.ts
+++ b/src/tool/tools/tool_context.ts
@@ -34,7 +34,7 @@ export function registerContext() {
         if (ctx_type === "private") {
             const ui = await session.context.findUser(ctx, name, true);
             if (ui === null) return `未找到<${name}>`;
-            if (ui.userId === ctx.player.userId && ctx.isPrivate) return `向当前私聊发送消息无需调用函数`;
+            if (ui.userId === ctx.player!.userId && ctx.isPrivate) return `向当前私聊发送消息无需调用函数`;
             if (ui.userId === ctx.endPoint.userId) return `禁止向自己发送消息`;
 
             ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ''));
@@ -42,7 +42,7 @@ export function registerContext() {
         } else if (ctx_type === "group") {
             const gi = await session.context.findGroup(ctx, name);
             if (gi === null) return `未找到<${name}>`;
-            if (gi.groupId === ctx.group.groupId) return `向当前群聊发送消息无需调用函数`;
+            if (gi.groupId === ctx.group!.groupId) return `向当前群聊发送消息无需调用函数`;
 
             ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, '', gi.groupId));
             session = getSession(gi.groupId);

--- a/src/tool/tools/tool_message.ts
+++ b/src/tool/tools/tool_message.ts
@@ -51,8 +51,8 @@ export function registerMessage() {
 
         const { SHOW_NUMBER: showNumber = true } = Config.message;
         const source = ctx.isPrivate ?
-            `来自<${ctx.player.name}>${showNumber ? `(${ctx.player.userId.replace(/^.+:/, '')})` : ``}` :
-            `来自群聊<${ctx.group.groupName}>${showNumber ? `(${ctx.group.groupId.replace(/^.+:/, '')})` : ``}`;
+            `来自<${ctx.player!.name}>${showNumber ? `(${ctx.player!.userId.replace(/^.+:/, '')})` : ``}` :
+            `来自群聊<${ctx.group!.groupName}>${showNumber ? `(${ctx.group!.groupId.replace(/^.+:/, '')})` : ``}`;
 
         const segs = parseSpecialTokens(content);
         const originalImages: Image[] = [];
@@ -71,7 +71,7 @@ export function registerMessage() {
         if (msg_type === "private") {
             const ui = await session.context.findUser(ctx, name, true);
             if (ui === null) return `未找到<${name}>`;
-            if (ui.userId === ctx.player.userId && ctx.isPrivate) return `向当前私聊发送消息无需调用函数`;
+            if (ui.userId === ctx.player!.userId && ctx.isPrivate) return `向当前私聊发送消息无需调用函数`;
             if (ui.userId === ctx.endPoint.userId) return `禁止向自己发送消息`;
 
             ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, ui.userId, ''));
@@ -79,7 +79,7 @@ export function registerMessage() {
         } else if (msg_type === "group") {
             const gi = await session.context.findGroup(ctx, name);
             if (gi === null) return `未找到<${name}>`;
-            if (gi.groupId === ctx.group.groupId) return `向当前群聊发送消息无需调用函数`;
+            if (gi.groupId === ctx.group!.groupId) return `向当前群聊发送消息无需调用函数`;
 
             ({ ctx } = getCtxAndMsg(ctx.endPoint.userId, '', gi.groupId));
             session = getSession(gi.groupId);
@@ -138,10 +138,10 @@ export function registerMessage() {
 
         const { content } = await transformArrayToContent(ctx, messageArray);
 
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
         const uid = `QQ:${result.sender.user_id}`;
         ({ ctx } = getCtxAndMsg(epId, uid, gid));
-        const name = ctx.player.name || '未知用户';
+        const name = ctx.player!.name || '未知用户';
         const prefix = isPrefix ? `<|from:${name}${showNumber ? `(${uid.replace(/^.+:/, '')})` : ``}|>` : '';
 
         return prefix + content;
@@ -170,7 +170,7 @@ export function registerMessage() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const result = await getMsg(epId, transformMsgIdBack(msg_id));
         if (!result) return `获取消息 ${msg_id} 失败`;

--- a/src/tool/tools/tool_voice.ts
+++ b/src/tool/tools/tool_voice.ts
@@ -111,7 +111,7 @@ export function registerRecord() {
         if (!netExists()) return `未找到ob11网络连接依赖，请提示用户安装`;
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
+        const gid = ctx.group!.groupId;
 
         const characterId = characterMap[character];
         await sendGroupAISound(epId, characterId, gid.replace(/^.+:/, ''), text);

--- a/src/utils/seal.ts
+++ b/src/utils/seal.ts
@@ -16,7 +16,7 @@ export function createCtx(epId: string, msg: seal.Message): seal.MsgContext | un
         if (eps[i].userId === epId) {
             const ctx = seal.createTempCtx(eps[i], msg);
             ctx.isPrivate = msg.messageType === 'private';
-            if (ctx.player.userId === epId) ctx.player.name = seal.formatTmpl(ctx, "核心:骰子名字");
+            if (ctx.player!.userId === epId) ctx.player!.name = seal.formatTmpl(ctx, "核心:骰子名字");
             return ctx;
         }
     }
@@ -39,5 +39,5 @@ export function getSessionCtxAndMsg(epId: string, sid: string, isPrivate: boolea
 }
 
 export function getSessionId(ctx: seal.MsgContext): string {
-    return ctx.isPrivate ? ctx.player.userId : ctx.group.groupId;
+    return ctx.isPrivate ? ctx.player!.userId : ctx.group!.groupId;
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -186,19 +186,19 @@ export async function transformArrayToContent(ctx: seal.MsgContext, messageArray
             }
             case 'at': {
                 const epId = ctx.endPoint.userId;
-                const gid = ctx.group.groupId;
+                const gid = ctx.group!.groupId;
                 const uid = `QQ:${seg.data.qq || ''}`;
                 ({ ctx } = getCtxAndMsg(epId, uid, gid));
-                const name = ctx.player.name || '未知用户';
+                const name = ctx.player!.name || '未知用户';
                 content += `<|at:${name}|>`;
                 break;
             }
             case 'poke': {
                 const epId = ctx.endPoint.userId;
-                const gid = ctx.group.groupId;
+                const gid = ctx.group!.groupId;
                 const uid = `QQ:${seg.data.qq || ''}`;
                 ({ ctx } = getCtxAndMsg(epId, uid, gid));
-                const name = ctx.player.name || '未知用户';
+                const name = ctx.player!.name || '未知用户';
                 content += `<|poke:${name}|>`;
                 break;
             }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -49,8 +49,8 @@ export async function replyToSender(ctx: seal.MsgContext, msg: seal.Message, ses
         if (messageArray.length === 0) return '';
 
         const epId = ctx.endPoint.userId;
-        const gid = ctx.group.groupId;
-        const uid = ctx.player.userId;
+        const gid = ctx.group!.groupId;
+        const uid = ctx.player!.userId;
         if (msg.messageType === 'private') {
             const result = await sendPrivateMsg(epId, uid.replace(/^.+:/, ''), messageArray);
             if (result?.message_id) {

--- a/types/seal.d.ts
+++ b/types/seal.d.ts
@@ -1,104 +1,99 @@
 declare namespace seal {
-  /** 信息上下文 */
+  /**
+   * 消息上下文。指令回调 / 事件回调的第一个参数。
+   * 包含了当前消息所在的群、发送者、通信端点等全部运行时信息。
+   */
   export interface MsgContext {
+    /** 当前消息对应的通信端点（骰子账号）信息 */
     endPoint: EndPointInfo;
-    /** 当前群信息 */
-    group: GroupInfo;
-    /** 当前群的玩家数据 */
-    player: GroupPlayerInfo;
-    /** 当前群内是否启用bot（注:强制@时这个值也是true，此项是给特殊指令用的） */
+    /** 当前群信息；私聊时可能为 null */
+    group: GroupInfo | null;
+    /** 当前群内玩家数据；私聊时可能为 null */
+    player: GroupPlayerInfo | null;
+    /**
+     * 当前群内是否启用 bot。
+     * 注意：强制 @ 时这个值也为 true，此字段是给特殊指令用的。
+     */
     isCurGroupBotOn: boolean;
-    /** 是否私聊 */
+    /** 是否为私聊消息 */
     isPrivate: boolean;
-    /** 权限等级 40邀请者 50管理 60群主 100master */
+    /**
+     * 暗骰 / 特殊发送标记。
+     * 一般与 `onMessageSend` 的 flag 参数配合使用，多为空字符串。
+     */
+    commandHideFlag: string;
+    /**
+     * 权限等级：
+     * -30 拉黑、40 邀请者、50 管理、60 群主、70 信任、100 master
+     */
     privilegeLevel: number;
     /** 代骰附加文本 */
-    delegateText: string
-    /** 对通知列表发送消息 */
-    notice(text: string): void
-
-    // 谨慎使用角色卡相关 api ，有可能写坏数据库
-
-    /** 绑定角色卡到当前群 */
-    chBindCur(name: string): void
-    /* 获取当前群绑定角色 返回名字或者空字符串*/
-    chBindCurGet(): string
-    /** 获取一个正在绑定状态的卡，可用于该卡片是否绑卡检测 */
-    chBindGet(name: string): ValueMap
-    /** 返回当前卡绑定的群列表 */
-    chBindGetList(): string[]
-    /** 解除某个角色的绑定 返回绑定过的群列表 */
-    chUnbind(name: string): string[]
-    /** 解除绑定 成功返回 `[角色名,true]`，失败返回 `["",false]`  */
-    chUnbindCur(name: string): [string, boolean]
-
-
-    /* 判断角色是否存在 */
-    chExists(name: string): boolean
-    /** 新建角色 成功 true；存在同名角色 false */
-    chNew(name: string): boolean
-    /** 清空当前群角色卡变量 返回被清空的变量数量 */
-    chVarsClear(): number
-    /** 获取当前角色 ValueMap */
-    chVarsGet(): [ValueMap, boolean]
-    /** 获取当前角色变量数量，底层为 `ValueMap.len()` */
-    chVarsNumGet(): number
-    /** 更新角色卡操作时间 */
-    chVarsUpdateTime(): void
-
-    // 这些接口不推荐使用，太麻烦了
-    /**  获取角色数据 成功返回 ValueMap ，失败返回 null */
-    chGet(name: string): ValueMap | null
-    /** 加载角色，成功返回 ValueMap ，失败返回 null */
-    chLoad(name: string): ValueMap | null
-    /** 加载个人群内数据 */
-    loadGroupVars(g: GroupInfo, p: GroupPlayerInfo): void
-    /** 加载个人全局数据 */
-    loadPlayerGlobalVars(): void
-    /** 加载个人群内数据 */
-    loadPlayerGroupVars(): void
-
+    delegateText: string;
+    /**
+     * 使用当前消息上下文的账号发送一条“通知”给通知列表（骰主）。
+     * @param text 通知内容
+     */
+    notice(text: string): void;
   }
 
+  /**
+   * 键值对数据表（dicescript.ValueMap）。
+   * 注意：当前版本没有公开 API 直接返回该类型，此处保留以便
+   * 未来扩展使用；方法名对应 dicescript 当前实现的导出方法（小写化后）。
+   */
   export interface ValueMap {
-    /** 获取 */
-    get(k: string): [any, boolean]
-    /** 添加 */
-    set(k: string, v: any): void
-    /** 删除 */
-    del(k: string): void
-    /** 数量 */
-    len(): number
-    /** 迭代 */
-    next(): [any, any, boolean]
-    /** 遍历 参数不能传入 `()=>null`，但可以传入 `()=>{}` 或者 `function(){}` */
-    iterate(fun: (k: string, v: any) => void): void
-    // 加锁
-    lock(): void
-    // 解锁
-    unlock(): void
+    /** 读取 key，返回值与是否存在 */
+    load(key: string): [any, boolean];
+    /** 写入 key=value */
+    store(key: string, value: any): void;
+    /** 删除 key */
+    delete(key: string): void;
+    /** 数据数量 */
+    length(): number;
+    /** 清空全部数据 */
+    clear(): void;
+    /**
+     * 遍历全部键值；回调返回 false 时停止遍历
+     * @param fn (key, value) => boolean
+     */
+    range(fn: (key: string, value: any) => boolean): void;
+    /** 若 key 存在则返回其值，否则写入并返回 value；loaded 表示是否为已存在 */
+    loadOrStore(key: string, value: any): [any, boolean];
+    /** 若 key 存在则返回其值，否则返回 null */
+    mustLoad(key: string): any;
+    /** 删除并返回原值；loaded 表示是否存在 */
+    loadAndDelete(key: string): [any, boolean];
+    /** 序列化为 JSON 字符串 */
+    toJSON(): string;
   }
 
   /** 群信息 */
   export interface GroupInfo {
+    /** 是否在群内开启（已过渡为象征意义，主要看扩展是否激活） */
     active: boolean;
+    /** 群号 */
     groupId: string;
+    /** 服务器群组号（discord/kook/dodo 等平台有值） */
+    guildId: string;
+    /** 频道号（频道制平台有值） */
+    channelId: string;
+    /** 群名称 */
     groupName: string;
-    /** COC规则序号 */
+    /** COC 规则序号（对应 .setcoc） */
     cocRuleIndex: number;
-    /** 当前log名字，若未开启为空 */
+    /** 当前 log 名字，未开启日志时为空字符串 */
     logCurName: string;
-    /** 当前log是否开启 */
+    /** 当前 log 是否开启 */
     logOn: boolean;
-    /** 是否显示入群迎新信息 */
+    /** 最近一次发送骰子（消息）的时间戳（秒） */
+    recentDiceSendTime: number;
+    /** 是否显示入群欢迎 */
     showGroupWelcome: boolean;
-    /** 入群迎新文本 */
+    /** 入群欢迎文本 */
     groupWelcomeMessage: string;
-    /** 最后指令时间(时间戳) */
-    recentCommandTime: number;
-    /** 入群时间(时间戳) */
+    /** 入群时间（时间戳，秒） */
     enteredTime: number;
-    /** 邀请人ID */
+    /** 邀请人 ID */
     inviteUserId: string;
   }
 
@@ -106,231 +101,319 @@ declare namespace seal {
   export interface GroupPlayerInfo {
     /** 用户昵称 */
     name: string;
-    /** 用户ID */
+    /** 用户 ID */
     userId: string;
-    /** 上次执行指令时间 */
+    /** 上次发送指令时间（时间戳，秒） */
     lastCommandTime: number;
-    /** 上次发送指令时间(即sn) */
+    /** 名片模板（自动设置的名片格式） */
     autoSetNameTemplate: string;
   }
 
   /** 消息详情 */
   export interface Message {
-    /** 当前平台，如QQ */
+    /** 当前平台，如 QQ */
     platform: string;
     /** 消息内容 */
     message: string;
-    /** 发送时间 */
+    /** 发送时间（时间戳，秒） */
     time: number;
-    /** 群消息/私聊消息 */
+    /** 群消息 / 私聊消息 */
     messageType: 'group' | 'private';
-    /** 群ID */
+    /** 群号（群聊消息） */
     groupId: string;
-    /** 服务器ID */
+    /** 服务器群组号（discord/kook/dodo 等平台有值） */
     guildId: string;
+    /** 频道号（频道制平台有值） */
+    channelId: string;
     /** 发送者信息 */
     sender: Sender;
-    /** 原始ID，用于撤回等情况 */
+    /** 原始消息 ID，用于撤回等场景 */
     rawId: string | number;
+    /**
+     * 消息段（富文本元素）。目前仅部分平台（如 Milky）支持，
+     * 其他平台通常为空数组。
+     */
+    segment: MessageSegment[];
   }
 
-  /** 创建一个 Message 对象 */
-  export function newMessage(): Message;
-
-  /** 创建一个 ctx 对象 */
-  export function createTempCtx(
-    endPoint: EndPointInfo,
-    msg: Message
-  ): MsgContext;
+  /** 消息段（富文本元素），type 与 data 由各平台决定 */
+  export interface MessageSegment {
+    /** 元素类型，如 text / at / image / reply 等 */
+    type: string;
+    /** 元素数据（原始 JSON） */
+    data: any;
+  }
 
   /** 发送者信息 */
   export interface Sender {
+    /** 昵称 */
     nickname: string;
+    /** 用户 ID */
     userId: string;
   }
 
-  /** 通信端点，即骰子关联的帐号的信息 */
+  /**
+   * 通信端点，即骰子关联的账号信息。
+   * 顶层字段由 Go 嵌入结构体自动“提升”而来，可直接访问
+   * `endPoint.userId` 等；同时也存在 `baseInfo` 嵌套对象（字段相同）。
+   */
   export interface EndPointInfo {
+    /** uuid */
     id: string;
     /** 昵称 */
     nickname: string;
-    /** 状态 0 断开 1已连接 2连接中 3连接失败 */
+    /** 状态：0 断开、1 已连接、2 连接中、3 连接失败 */
     state: number;
-    /** 用户id */
+    /** 用户 ID */
     userId: string;
-    /** 命令执行数量 */
+    /** 拥有群数 */
+    groupNum: number;
+    /** 指令执行次数 */
     cmdExecutedNum: number;
-    /** 最后命令执行时间 */
+    /** 最后指令执行时间（时间戳，秒） */
     cmdExecutedLastTime: number;
-    /** 平台 */
+    /** 在线时长（秒） */
+    onlineTotalTime: number;
+    /** 平台，如 QQ */
     platform: string;
     /** 是否启用 */
     enable: boolean;
-
-    // adapter: PlatformAdapter;
+    /** 嵌套的基础信息对象（字段与顶层一致，goja 嵌入结构体暴露） */
+    baseInfo: {
+      id: string;
+      nickname: string;
+      state: number;
+      userId: string;
+      groupNum: number;
+      cmdExecutedNum: number;
+      cmdExecutedLastTime: number;
+      onlineTotalTime: number;
+      platform: string;
+      enable: boolean;
+    };
   }
 
+  /** @ 信息 */
   export interface AtInfo {
+    /** 被 @ 的用户 ID */
     userId: string;
   }
 
+  /** 关键字参数，如 `.ra 50 --key=20 --asm` */
   export interface Kwarg {
-    /** 名称 */
+    /** 参数名 */
     name: string;
-    /** 是否存在value */
+    /** 是否存在 value（即是否为 --key=value 形式） */
     valueExists: boolean;
-    /** value的值 */
+    /** value 的值 */
     value: string;
-    /** 将value转换为bool，如'0' ''等会自动转为false */
+    /** 将 value 转换为 bool；'0'、'' 等会自动转为 false */
     asBool: boolean;
   }
 
+  /** 指令参数 */
   export interface CmdArgs {
-    /** 当前命令，与指令的name相对，例如.ra时，command为ra */
+    /** 当前指令，与指令的 name 相对；如 `.ra` 时 command 为 ra */
     command: string;
-    /** 指令参数，如“.ra 力量 测试”时，参数1为“力量”，参数2为“测试” */
+    /**
+     * 指令参数列表。如 `.ra 力量 测试` 时，
+     * args[0] 为 '力量'，args[1] 为 '测试'
+     */
     args: string[];
-    /** 关键字参数 */
+    /** 关键字参数列表 */
     kwargs: Kwarg[];
-    /** 当前被at的有哪些 */
+    /** 被 @ 的列表 */
     at: AtInfo[];
     /** 参数的原始文本 */
     rawArgs: string;
-    /** 我被at了 */
+    /** 我是否被 @ */
     amIBeMentioned: boolean;
-    /** 同上，但要求是第一个被at的 */
+    /** 同上，但要求是第一个被 @ 的 */
     amIBeMentionedFirst: boolean;
-    /** 一种格式化后的参数，也就是中间所有分隔符都用一个空格替代 */
+    /** 格式化后的参数：所有分隔符均用单个空格替代 */
     cleanArgs: string;
-    // 暂不提供，未来可能有变化
+    /** 特殊执行次数，对应 `.ra10#50` 中的 10 */
     specialExecuteTimes: number;
-    // 但是额外指出， `ra10#50` 时此项 = 10，并且 argv[0] 会被处理为 50；请注意这一点
+    /** 原始命令（含指令前缀） */
     rawText: string;
-    // 原始文本
 
-    /** 获取关键字参数，如“.ra 50 --key=20 --asm”时，有两个kwarg，一个叫key，一个叫asm */
-    getKwarg(key: string): Kwarg;
-    /** 获取第N个参数，从1开始，如“.ra 力量50 推门” 参数1为“力量50”，参数2是“推门” */
+    /**
+     * 获取关键字参数，如 `.ra 50 --key=20 --asm`
+     * 返回名为 key 或 asm 的 Kwarg；不存在返回 null
+     */
+    getKwarg(key: string): Kwarg | null;
+    /**
+     * 获取第 N 个参数，从 1 开始。
+     * 如 `.ra 力量50 推门`：参数 1 为 '力量50'，参数 2 为 '推门'；
+     * 不存在时返回空字符串
+     */
     getArgN(n: number): string;
-    /** 分离前缀 如 `.stdel力量` => [del,力量] ，直接修改 argv 属性*/
-    chopPrefixToArgsWith(...s: string[]): boolean
-    /** 吃掉前缀并去除复数空格 `set xxx  xxx` => `xxx xxx`，返回修改后的字符串和是否修改成功的布尔值  */
-    eatPrefixWith(...s: string[]): [string, boolean]
-    /** 将第 n 个参数及之后参数用空格拼接起来; 如指令 `send to qq x1 x2`,n=3返回 `x1 x2` */
-    getRestArgsFrom(n: number): string
-    /** 检查第N项参数是否为某个字符串，n从1开始，若没有第n项参数也视为失败 */
-    isArgEqual(n: number, ...s: string[]): boolean
+    /**
+     * 拆分前缀，如 `.stdel力量` => `[del, 力量]`，直接修改 args 属性。
+     * 成功返回 true
+     */
+    chopPrefixToArgsWith(...s: string[]): boolean;
+    /**
+     * 吃掉前缀并去除多余空格，如 `set xxx  xxx` => `xxx xxx`。
+     * 返回修改后的字符串和是否修改成功的布尔值
+     */
+    eatPrefixWith(...s: string[]): [string, boolean];
+    /**
+     * 将第 N 个参数及之后的所有参数用空格拼接起来。
+     * 如指令 `send to qq x1 x2`，n=3 返回 `x1 x2`
+     */
+    getRestArgsFrom(n: number): string;
+    /**
+     * 检查第 N 项参数是否为某个字符串，n 从 1 开始；
+     * 若没有第 n 项参数也视为失败
+     */
+    isArgEqual(n: number, ...s: string[]): boolean;
   }
 
-
-  interface CmdItemInfo {
+  /** 指令定义 */
+  export interface CmdItemInfo {
+    /** 指令执行函数，返回执行结果 */
     solve: (ctx: MsgContext, msg: Message, cmdArgs: CmdArgs) => CmdExecuteResult | Promise<CmdExecuteResult>;
-
     /** 指令名称 */
     name: string;
-    /** 长帮助，带换行的较详细说明  */
+    /** 长帮助，带换行的较详细说明 */
     help: string;
+    /** 函数形式的帮助，存在时优先于 help */
+    helpFunc?: (isShort: boolean) => string;
     /** 允许代骰 */
     allowDelegate: boolean;
     /** 私聊不可用 */
     disabledInPrivate: boolean;
-
-    /** 高级模式。默认模式下行为是：需要在当前群/私聊开启，或@自己时生效(需要为第一个@目标)。一般不建议使用 */
-    // raw: boolean;
-    /** 是否检查当前可用状况，包括群内可用和是私聊两种方式，如失败不进入solve */
-    // checkCurrentBotOn: boolean;
-    /** 是否检查@了别的骰子，如失败不进入solve */
-    // checkMentionOthers: boolean;
+    /** 启用执行次数解析，即解析 `3#` 这样的文本 */
+    enableExecuteTimesParse: boolean;
+    /**
+     * 高级模式。默认模式下行为是：需要在当前群/私聊开启，
+     * 或 @ 自己时生效（需要为第一个 @ 目标）
+     */
+    raw: boolean;
+    /** 是否检查当前可用状况（群内可用/私聊），失败则不进入 solve */
+    checkCurrentBotOn: boolean;
+    /** 是否检查 @ 了别的骰子，失败则不进入 solve */
+    checkMentionOthers: boolean;
   }
 
-  /** 戳一戳事件 */
-  export interface PokeEvent {
-    /** 群ID */
-    groupId: string;
-    /** 戳一戳的发送者ID */
-    senderId: string;
-    /** 戳一戳的目标用户ID */
-    targetId: string;
-    /** 是否是私聊戳一戳 */
-    isPrivate: boolean;
-  }
-
-  interface ExtInfo {
-    /** 名字 */
-    name: string;
-    /** 版本 */
-    version: string;
-    /** 名字 */
-    author: string;
-    /** 指令映射 */
-    cmdMap: { [key: string]: CmdItemInfo };
-    /** 是否加载完成 */
-    isLoaded: boolean
-    /** 存放数据 */
-    storageSet(key: string, value: string): void;
-    /** 取数据 */
-    storageGet(key: string): string;
-    /** 匹配非指令消息 */
-    onNotCommandReceived: (ctx: MsgContext, msg: Message) => void
-    /** 试图匹配自定义指令（只对内置扩展有意义） */ // 已废弃
-    // onCommandOverride: (ctx: MsgContext, msg: Message, cmdArgs: CmdArgs) => boolean;
-    /** 监听 收到指令 事件 */
-    onCommandReceived: (ctx: MsgContext, msg: Message, cmdArgs: CmdArgs) => void
-    /** 监听 收到消息 事件，如 log 模块记录收到文本 */
-    onMessageReceived: (ctx: MsgContext, msg: Message) => void
-    /** 监听 发送消息 事件，如 log 模块记录指令文本 */
-    onMessageSend: (ctx: MsgContext, msg: Message) => void
-    /** 监听 戳一戳 事件 */
-    onPoke: (ctx: MsgContext, event: PokeEvent) => void
-    /** 获取扩展介绍文本 */
-    getDescText(): string
-    /** 监听 加载时 事件，如 deck 模块需要读取牌堆文件 */
-    onLoad: (...any: any) => void
-    /** 初始化数据，读写数据时会自动调用 */
-    storageInit(): void
-    /** 读数据 如果无需自定义错误处理就无需使用 */
-    storageGetRaw(k: string): string
-    /** 写数据 如果无需自定义错误处理就无需使用 */
-    storageSetRaw(k: string, v: string): void
-  }
-
-
-  interface CmdExecuteResult {
-    /** 是否顺利完成执行 */
+  /** 指令执行结果 */
+  export interface CmdExecuteResult {
+    /** 是否响应（处理）了此指令 */
     solved: boolean;
     /** 是否返回帮助信息 */
     showHelp: boolean;
   }
 
-  type BanRankType = number
-  /*
-    禁止等级
-    BanRankBanned = -30 
-    警告等级
-    BanRankWarn = -10
-    常规等级
-    BanRankNomal = 0
-    信任等级
-    BanRankTrust = 30
-  */
-  interface BanListInfoItem {
+  /** 扩展信息 */
+  export interface ExtInfo {
+    /** 名字（不能为 help / all，否则注册时直接 panic） */
+    name: string;
+    /** 别名 */
+    aliases: string[];
+    /** 版本 */
+    version: string;
+    /** 是否自动开启 */
+    autoActive: boolean;
+    /** 指令映射：key 为指令名，value 为指令定义 */
+    cmdMap: { [key: string]: CmdItemInfo };
+    /** 作者 */
+    author: string;
+    /** 是否加载完成 */
+    isLoaded: boolean;
+    /** 获取扩展介绍文本 */
+    getDescText(): string;
+    /** 监听 加载时 事件 */
+    onLoad: () => void;
+    /** 指令过滤后剩下的非指令消息 */
+    onNotCommandReceived: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 收到指令 事件 */
+    onCommandReceived: (ctx: MsgContext, msg: Message, cmdArgs: CmdArgs) => void;
+    /** 监听 收到消息 事件，如 log 模块记录收到文本 */
+    onMessageReceived: (ctx: MsgContext, msg: Message) => void;
+    /**
+     * 监听 发送消息 事件，如 log 模块记录指令文本。
+     * flag 为发送标记，通常为空字符串，具体取值由平台适配器决定
+     */
+    onMessageSend: (ctx: MsgContext, msg: Message, flag: string) => void;
+    /** 监听 消息撤回 事件 */
+    onMessageDeleted: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 消息编辑 事件 */
+    onMessageEdit: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 加入群聊 事件 */
+    onGroupJoined: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 群成员加入 事件 */
+    onGroupMemberJoined: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 加入服务器群组（频道） 事件 */
+    onGuildJoined: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 成为好友 事件 */
+    onBecomeFriend: (ctx: MsgContext, msg: Message) => void;
+    /** 监听 戳一戳 事件 */
+    onPoke: (ctx: MsgContext, event: PokeEvent) => void;
+    /** 监听 群成员被踢出 事件 */
+    onGroupLeave: (ctx: MsgContext, event: GroupLeaveEvent) => void;
+
+    /**
+     * 初始化扩展存储（storage.db），读写数据时会自动调用，一般无需手动调用。
+     * 失败时抛异常
+     */
+    storageInit(): void;
+    /** 关闭扩展存储，失败时抛异常 */
+    storageClose(): void;
+    /** 写入扩展存储 key=value，失败时抛异常 */
+    storageSet(key: string, value: string): void;
+    /** 读取扩展存储中 key 的值；key 不存在或失败时抛异常 */
+    storageGet(key: string): string;
+  }
+
+  /** 戳一戳事件 */
+  export interface PokeEvent {
+    /** 群号 */
+    groupId: string;
+    /** 戳人的用户 ID */
+    senderId: string;
+    /** 被戳的用户 ID */
+    targetId: string;
+    /** 是否私聊 */
+    isPrivate: boolean;
+  }
+
+  /** 群成员被踢出事件（所有 ID 均为 UNI-ID 格式，如 QQ:1234567890） */
+  export interface GroupLeaveEvent {
+    /** 发生踢人的群 ID */
+    groupId: string;
+    /** 被踢出的用户 ID */
+    userId: string;
+    /** 执行踢人操作的用户 ID */
+    operatorId: string;
+  }
+
+  /**
+   * 黑名单等级
+   * -30 禁止、-10 警告、0 正常、30 信任
+   */
+  export type BanRankType = number;
+
+  /** 黑名单记录项 */
+  export interface BanListInfoItem {
     /** 对象 ID */
     id: string;
     /** 对象名称 */
     name: string;
-    /** 怒气值。*/
+    /** 怒气值 */
     score: number;
-    /** 0 正常，-10 警告，-30 禁止，30 信任 */
+    /** 0 正常、-10 警告、-30 禁止、30 信任 */
     rank: number;
-    /** 历史记录时间戳 */
+    /** 事发时间列表（时间戳，秒） */
     times: number[];
     /** 拉黑原因记录 */
     reasons: string[];
-    /** 事发会话记录 */
+    /** 事发会话（地点）记录 */
     places: string[];
-    /** 首次记录时间 */
+    /** 上黑名单时间（时间戳，秒） */
     banTime: number;
   }
+
   /** 黑名单操作 */
   export const ban: {
     /**
@@ -341,7 +424,6 @@ declare namespace seal {
      * @param reason 拉黑原因
      */
     addBan(ctx: MsgContext, id: string, place: string, reason: string): void;
-
     /**
      * 信任指定 ID
      * @param ctx 上下文
@@ -350,352 +432,407 @@ declare namespace seal {
      * @param reason 信任原因
      */
     addTrust(ctx: MsgContext, id: string, place: string, reason: string): void;
-
     /**
      * 将用户从名单中删除
      * @param ctx 上下文对象
      * @param id 要移除的用户 ID
      */
     remove(ctx: MsgContext, id: string): void;
-
     /** 获取名单全部用户 */
     getList(): BanListInfoItem[];
-
     /**
-     * 获取指定 ID 的黑名单记录。返回值可能为空。
-     * @param id 用户群组
+     * 获取指定 ID 的黑名单记录，不存在时返回 null
+     * @param id 用户或群组 ID
      */
-    getUser(id: string): BanListInfoItem;
+    getUser(id: string): BanListInfoItem | null;
+  };
+
+  /** 插件配置项 */
+  export interface ConfigItem {
+    /** 配置项名称 */
+    key: string;
+    /** 配置类型：string / int / bool / float / template / option / task:cron / task:daily */
+    type: string;
+    /** 默认值 */
+    defaultValue: any;
+    /** 当前值 */
+    value: any;
+    /** 可选值（option 类型） */
+    option: any;
+    /** 是否已废弃 */
+    deprecated: boolean;
+    /** 描述 */
+    description: string;
   }
 
-  interface ConfigItem {
-    key: string,
-    type: string,
-    defaultValue: any,
-    value: any,
-    option: any,
-    deprecated: boolean,
-    description: string,
-    group?: string
-  }
-  type TimeOutTaskType = 'cron' | 'daily'
-  export const ext: {
-    /**
-     * 新建一个扩展
-     */
-    new: (name: string, author: string, version: string) => ExtInfo;
-
-    /**
-     * 创建指令结果对象
-     * @param success 是否执行成功
-     */
-    newCmdExecuteResult(success: boolean): CmdExecuteResult;
-
-    /**
-     * 注册一个扩展
-     * @param ext
-     */
-    register(ext: ExtInfo): unknown;
-
-    /**
-     * 按名字查找扩展对象
-     * @param name
-     */
-    find(name: string): ExtInfo;
-    /** 创建指令对象 */
-    newCmdItemInfo(): CmdItemInfo;
-    /**
-     * 注册一个字符串类型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    registerStringConfig(ext: ExtInfo, key: string, defaultValue: string, desc?: string, group?: string): unknown;
-    /**
-     * 注册一个整型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    registerIntConfig(ext: ExtInfo, key: string, defaultValue: number, desc?: string, group?: string): unknown;
-    /**
-     * 注册一个布尔类型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    registerBoolConfig(ext: ExtInfo, key: string, defaultValue: boolean, desc?: string, group?: string): unknown;
-    /**
-     * 注册一个浮点数类型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    registerFloatConfig(ext: ExtInfo, key: string, defaultValue: number, desc?: string, group?: string): unknown;
-    /**
-     * 注册一个template类型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    registerTemplateConfig(ext: ExtInfo, key: string, defaultValue: string[], desc?: string, group?: string): unknown;
-    /**
-     * 注册一个option类型的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项默认值
-     * @param option 可选项
-     * @param desc 描述
-     */
-    registerOptionConfig(ext: ExtInfo, key: string, defaultValue: string, option: string[], desc?: string, group?: string): unknown;
-    /**
-     * 创建一个新的配置项
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     * @param defaultValue 配置项值
-     * @param desc 描述
-     */
-    newConfigItem(ext: ExtInfo, key: string, defaultValue: any, desc: string): ConfigItem;
-    /**
-     * 注册配置
-     * @param ext 扩展对象 
-     * @param configs 配置项对象
-     */
-    registerConfig(ext: ExtInfo, ...configs: ConfigItem[]): unknown;
-    /**
-     * 获取指定名称的配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getConfig(ext: ExtInfo, key: string): ConfigItem;
-    /**
-     * 获取指定名称的字符串类型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getStringConfig(ext: ExtInfo, key: string): string;
-    /**
-     * 获取指定名称的整型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getIntConfig(ext: ExtInfo, key: string): number;
-    /**
-     * 获取指定名称的布尔类型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getBoolConfig(ext: ExtInfo, key: string): boolean;
-    /**
-     * 获取指定名称的浮点数类型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getFloatConfig(ext: ExtInfo, key: string): number;
-    /**
-     * 获取指定名称的template类型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getTemplateConfig(ext: ExtInfo, key: string): string[];
-    /**
-     * 获取指定名称的option类型配置项对象
-     * @param ext 扩展对象
-     * @param key 配置项名称
-     */
-    getOptionConfig(ext: ExtInfo, key: string): string;
-    /**
-     * 卸载对应名称的配置项
-     * @param ext 扩展对象
-     * @param keys 配置项名称
-     */
-    unregisterConfig(ext: ExtInfo, ...keys: string[]): void;
-
-    /**
-     * 注册定时任务
-     * @param ext 扩展对象
-     * @param taskType cron格式/每日时钟格式
-     * @param value 5位cron表达式/数字时钟 例如 * * * * *或者8:30
-     * @param fn 定时任务内容
-     * @param key 定时任务名称
-     * @param desc 定时任务描述
-     */
-    registerTask(ext: ExtInfo, taskType: TimeOutTaskType, value: string, fn: Function, key?: string, desc?: string): void;
+  /**
+   * 定时任务对象，由 `seal.ext.registerTask` 返回。
+   * 通过 key 注册的任务会在配置项中记录，可被用户修改；
+   * 任务可调用 on()/off() 手动启停。
+   */
+  export interface JsScriptTask {
+    /** 启用任务，成功返回 true */
+    on(): boolean;
+    /** 停用任务，成功返回 true */
+    off(): boolean;
   }
 
-  interface CocRuleInfo {
+  /** 定时任务回调上下文 */
+  export interface JsScriptTaskCtx {
+    /** 触发时刻（时间戳，秒） */
+    now: number;
+    /** 任务 key（未提供 key 时为空字符串） */
+    key: string;
+  }
+
+  /** COC 自定义规则 */
+  export interface CocRuleInfo {
     /** 序号 */
     index: number;
     /** .setcoc key */
     key: string;
-    /** 已切换至规则 Name: Desc */
+    /** 已切换至规则的显示名 */
     name: string;
     /** 规则描述 */
     desc: string;
-
     /**
-     * 检定函数
+     * 判定函数
      * @param ctx 上下文对象
      * @param d100 使用骰子骰出的值
-     * @param checkValue 检定线，对应属性，例如力量、敏捷等
+     * @param checkValue 判定线，对应属性，如力量、敏捷等
+     * @param difficultyRequired 难度要求：1 普通、2 困难、3 极难、4 大成功
      */
-    check(ctx: MsgContext, d100: number, checkValue: number): CocRuleCheckRet;
+    check(ctx: MsgContext, d100: number, checkValue: number, difficultyRequired: number): CocRuleCheckRet;
   }
 
-  interface CocRuleCheckRet {
-    /** 成功级别，失败小于0，成功大于0。大失败-2 失败-1 成功1 困难成功2 极难成功3 大成功4 */
+  /** COC 判定结果 */
+  export interface CocRuleCheckRet {
+    /**
+     * 成功级别：-2 大失败、-1 失败、1 成功、2 困难成功、3 极难成功、4 大成功
+     */
     successRank: number;
     /** 大成功数值 */
     criticalSuccessValue: number;
   }
 
-  export const coc: {
-    newRule(): CocRuleInfo;
-    newRuleCheckResult(): CocRuleCheckRet;
-    registerRule(rule: CocRuleInfo): boolean;
+  /** 版本信息（`seal.getVersion()` 的返回） */
+  export type VersionDetailsType = {
+    /** 内部版本号，新版永远比旧版大 */
+    versionCode: number;
+    /** 版本号+日期，如 1.4.6+20240810 */
+    version: string;
+    /** 版本号，如 1.4.6 */
+    versionSimple: string;
+    /** 版本详情 */
+    versionDetail: {
+      major: number;
+      minor: number;
+      patch: number;
+      prerelease: string;
+      /** 构建日期，如 20240810 */
+      buildMetaData: string;
+    };
+  };
+
+  /** 抽牌结果 */
+  export interface deckResult {
+    /** 牌堆是否存在 */
+    exists: boolean;
+    /** 错误信息（无错误时为空字符串） */
+    err: string;
+    /** 抽牌结果，失败时为 null */
+    result: string | null;
   }
 
-  /** 代骰模式下，获取被代理人信息 */
-  export function getCtxProxyFirst(ctx: MsgContext, cmdArgs: CmdArgs): MsgContext;
-  /** 回复发送者(发送者私聊即私聊回复，群内即群内回复) */
-  export function replyToSender(ctx: MsgContext, msg: Message, text: string): void;
-  /** 回复发送者(私聊回复，典型应用场景如暗骰) */
-  export function replyPerson(ctx: MsgContext, msg: Message, text: string): void;
-  /** 回复发送者(群内回复，私聊时无效) */
-  export function replyGroup(ctx: MsgContext, msg: Message, text: string): void;
-  /** 格式化文本 等价于 `text` 指令 */
-  export function format(ctx: MsgContext, text: string): string;
-  /** 获取回复文案 */
-  export function formatTmpl(ctx: MsgContext, text: string): string
-  /** 代骰模式下，获取被代理人信息 */
-  export function getCtxProxyFirst(ctx: MsgContext, cmdArgs: CmdArgs): MsgContext;
-  /** 新建一条消息 */
-  export function newMessage(): Message;
-  /** 创建一个临时Context */
-  export function createTempCtx(ep: EndPointInfo, msg: Message): MsgContext;
-  /** 应用名片模板，返回值为格式化完成的名字。此时已经设置好名片(如有权限) */
-  export function applyPlayerGroupCardByTemplate(ctx: MsgContext, tmpl: string): string;
+  /** 扩展管理 */
+  export const ext: {
+    /**
+     * 新建一个扩展对象（尚未注册）
+     * @param name 扩展名（不能是 help / all，否则注册时直接 panic）
+     * @param author 作者
+     * @param version 版本
+     */
+    new: (name: string, author: string, version: string) => ExtInfo;
+    /**
+     * 创建指令结果对象
+     * @param solved 是否执行成功
+     */
+    newCmdExecuteResult(solved: boolean): CmdExecuteResult;
+    /**
+     * 创建指令对象，然后设置 name/solve 等字段
+     */
+    newCmdItemInfo(): CmdItemInfo;
+    /**
+     * 注册扩展；会触发扩展的 onLoad 回调。
+     * 同名的旧扩展会被替换（重载场景）
+     */
+    register(ext: ExtInfo): void;
+    /**
+     * 按名字查找已注册的扩展对象，不存在时返回 null
+     */
+    find(name: string): ExtInfo | null;
+
+    /**
+     * 注册一个字符串类型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param desc 描述
+     */
+    registerStringConfig(ext: ExtInfo, key: string, defaultValue: string, desc?: string, group?: string): void;
+    /**
+     * 注册一个整型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param desc 描述
+     */
+    registerIntConfig(ext: ExtInfo, key: string, defaultValue: number, desc?: string, group?: string): void;
+    /**
+     * 注册一个布尔类型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param desc 描述
+     */
+    registerBoolConfig(ext: ExtInfo, key: string, defaultValue: boolean, desc?: string, group?: string): void;
+    /**
+     * 注册一个浮点数类型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param desc 描述
+     */
+    registerFloatConfig(ext: ExtInfo, key: string, defaultValue: number, desc?: string, group?: string): void;
+    /**
+     * 注册一个 template（文本模板）类型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值（字符串数组）
+     * @param desc 描述
+     */
+    registerTemplateConfig(ext: ExtInfo, key: string, defaultValue: string[], desc?: string, group?: string): void;
+    /**
+     * 注册一个 option（下拉选择）类型的配置项
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param option 可选项
+     * @param desc 描述
+     */
+    registerOptionConfig(ext: ExtInfo, key: string, defaultValue: string, option: string[], desc?: string, group?: string): void;
+    /**
+     * 创建一个新的配置项对象（再通过 registerConfig 注册）
+     * @param ext 扩展对象（需先 register）
+     * @param key 配置项名称
+     * @param defaultValue 配置项默认值
+     * @param desc 描述
+     */
+    newConfigItem(ext: ExtInfo, key: string, defaultValue: any, desc: string): ConfigItem;
+    /**
+     * 批量注册配置项
+     * @param ext 扩展对象（需先 register）
+     * @param configs 配置项对象
+     */
+    registerConfig(ext: ExtInfo, ...configs: ConfigItem[]): void;
+    /**
+     * 获取指定名称的配置项对象，不存在返回 null
+     */
+    getConfig(ext: ExtInfo, key: string): ConfigItem | null;
+    /**
+     * 获取字符串配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getStringConfig(ext: ExtInfo, key: string): string;
+    /**
+     * 获取整型配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getIntConfig(ext: ExtInfo, key: string): number;
+    /**
+     * 获取布尔配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getBoolConfig(ext: ExtInfo, key: string): boolean;
+    /**
+     * 获取浮点数配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getFloatConfig(ext: ExtInfo, key: string): number;
+    /**
+     * 获取 template 配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getTemplateConfig(ext: ExtInfo, key: string): string[];
+    /**
+     * 获取 option 配置的值；配置不存在或类型不匹配时抛异常
+     */
+    getOptionConfig(ext: ExtInfo, key: string): string;
+    /**
+     * 注销指定名称的配置项
+     * @param ext 扩展对象
+     * @param keys 配置项名称
+     */
+    unregisterConfig(ext: ExtInfo, ...keys: string[]): void;
+    /**
+     * 注册定时任务
+     * @param ext 扩展对象（需先 register）
+     * @param taskType 任务类型：cron 表达式 / 每日时钟
+     * @param value cron 表达式（如 0 0 * * *）或每日时间（如 00:01）
+     * @param fn 定时任务回调，参数为任务上下文
+     * @param key 定时任务名称（提供后可在配置中修改触发时间）
+     * @param desc 定时任务描述
+     * @returns 任务对象，可调用 on()/off() 启停
+     */
+    registerTask(
+      ext: ExtInfo,
+      taskType: TimeOutTaskType,
+      value: string,
+      fn: (taskCtx: JsScriptTaskCtx) => void,
+      key?: string,
+      desc?: string
+    ): JsScriptTask;
+  };
+
+  /** 定时任务类型：cron 表达式 / 每日时钟 */
+  export type TimeOutTaskType = 'cron' | 'daily';
+
+  /** COC 规则自定义 */
+  export const coc: {
+    /** 创建一个新的 COC 规则对象 */
+    newRule(): CocRuleInfo;
+    /** 创建一个新的判定结果对象 */
+    newRuleCheckResult(): CocRuleCheckRet;
+    /** 注册自定义 COC 规则，成功返回 true */
+    registerRule(rule: CocRuleInfo): boolean;
+  };
+
+  /** 牌堆 */
+  export const deck: {
+    /**
+     * 抽牌
+     * @param ctx 上下文
+     * @param name 牌堆名
+     * @param isShuffle 是否放回（true 放回 / false 不放回）
+     */
+    draw(ctx: MsgContext, name: string, isShuffle: boolean): deckResult;
+    /** 重新加载全部牌堆（改动牌堆文件后调用） */
+    reload(): void;
+  };
+
+  /** 游戏规则系统 */
+  export const gameSystem: {
+    /**
+     * 添加一个规则模板，需为 JSON 文本格式；解析失败或同名模板已存在时抛异常
+     */
+    newTemplate(data: string): void;
+    /**
+     * 添加一个规则模板，需为 YAML 文本格式；解析失败或同名模板已存在时抛异常
+     */
+    newTemplateByYaml(data: string): void;
+  };
+
+  /** 变量读写（VM 变量，如 `$t`、`$g`） */
+  export const vars: {
+    /**
+     * 读取整数变量：VM 中存在 key 且类型正确时返回 `[number, true]`，否则 `[0, false]`
+     */
+    intGet(ctx: MsgContext, key: string): [number, boolean];
+    /**
+     * 写入整数变量：key=value，等价于指令 `text {key=value}`，value 类型为数字
+     */
+    intSet(ctx: MsgContext, key: string, value: number): void;
+    /**
+     * 读取字符串变量：VM 中存在 key 且类型正确时返回 `[string, true]`，否则 `['', false]`
+     */
+    strGet(ctx: MsgContext, key: string): [string, boolean];
+    /**
+     * 写入字符串变量：key=value，等价于指令 `text {key=value}`，value 类型为字符串
+     */
+    strSet(ctx: MsgContext, key: string, value: string): void;
+    /**
+     * 写入计算表达式变量：value 为 dicescript 表达式文本，
+     * 读取时才会求值
+     */
+    computedSet(ctx: MsgContext, key: string, value: string): void;
+    /**
+     * 读取计算表达式变量：返回 `[表达式文本, boolean]`
+     */
+    computedGet(ctx: MsgContext, key: string): [string, boolean];
+  };
 
   /**
-   * 禁言
-   * @param ctx 上下文
-   * @param groupID QQ群ID
-   * @param userID 禁言对象ID
-   * @param duration 禁言时间
+   * 创建一条新的空消息对象
    */
-  export function memberBan(ctx: MsgContext, groupID: string, userID: string, duration: number): void;
+  export function newMessage(): Message;
   /**
-   * 踢人
-   * @param ctx 上下文
-   * @param groupID QQ群ID
-   * @param userID 踢出对象ID
+   * 通过通信端点对象创建临时上下文，与 getEndPoints 共用
+   * @param ep 通信端点对象
+   * @param msg 消息对象（需有 messageType 与 sender.userId）
    */
-  export function memberKick(ctx: MsgContext, groupID: string, userID: string): void;
+  export function createTempCtx(ep: EndPointInfo, msg: Message): MsgContext;
   /**
-   * 执行海豹dicescript
-   * @param ctx 上下文
-   * @param s 指令文本
+   * 回复发送者（发送者私聊则私聊回复，群内则群内回复）
    */
-  export function formatTmpl(ctx: MsgContext, s: string): string;
+  export function replyToSender(ctx: MsgContext, msg: Message, text: string): void;
   /**
-   * 创建at列表里第一个用户的代骰上下文
+   * 回复发送者（强制私聊回复），典型应用场景如暗骰
+   */
+  export function replyPerson(ctx: MsgContext, msg: Message, text: string): void;
+  /**
+   * 回复发送者（群内回复），私聊时无效
+   */
+  export function replyGroup(ctx: MsgContext, msg: Message, text: string): void;
+  /**
+   * 格式化文本，等价于 `text` 指令（dicescript 求值）
+   */
+  export function format(ctx: MsgContext, text: string): string;
+  /**
+   * 获取回复文案（文本模板 + dicescript 求值）
+   */
+  export function formatTmpl(ctx: MsgContext, text: string): string;
+  /**
+   * 创建 @ 列表中第一个用户的代骰上下文
    * @param ctx 上下文
    * @param cmdArgs 指令参数
    */
   export function getCtxProxyFirst(ctx: MsgContext, cmdArgs: CmdArgs): MsgContext;
   /**
-   * 通过通信端点对象创建上下文，与getEndPoints共用
-   * @param ep 通信端点对象
-   * @param msg 消息对象
+   * 创建 @ 列表中指定序号用户的代骰上下文（pos 从 0 开始）
+   * @param ctx 上下文
+   * @param cmdArgs 指令参数
+   * @param pos @ 列表中的序号
    */
-  export function createTempCtx(ep: EndPointInfo, msg: Message): MsgContext;
+  export function getCtxProxyAtPos(ctx: MsgContext, cmdArgs: CmdArgs, pos: number): MsgContext;
   /**
-   * 
+   * 应用名片模板，返回格式化完成的名字；此时已设置好名片（如有权限）
    * @param ctx 上下文
    * @param tmpl 模板文本
    */
   export function applyPlayerGroupCardByTemplate(ctx: MsgContext, tmpl: string): string;
   /**
-   * 创建at列表里指定用户的代骰上下文
+   * 设置玩家群名片（应用名片模板），返回格式化后的文本；失败时抛异常
    * @param ctx 上下文
-   * @param cmdArgs 指令参数
-   * @param pos at列表的序数
+   * @param tmpl 模板文本
    */
-  export function getCtxProxyAtPos(ctx: MsgContext, cmdArgs: CmdArgs, pos: number): MsgContext;
-
-  type VersionDetailsType = {
-    // 
-    versionCode: number
-    // 版本号+日期 如 1.4.6+20240810
-    version: string
-    // 版本号 如 1.4.6
-    versionSimple: string
-
-    versionDetail: {
-
-      major: number
-
-      minor: number
-
-      patch: number
-
-      prerelease: string
-      // 创建日期 如 20240810
-      buildMetaData: string
-    }
-  }
-  /** 获取版本信息  */
+  export function setPlayerGroupCard(ctx: MsgContext, tmpl: string): string;
+  /**
+   * 通过 base64 返回图片临时地址（file:// 路径）
+   * @param base64 图片 base64 数据；非法时抛异常
+   */
+  export function base64ToImage(base64: string): string;
+  /**
+   * 禁言
+   * @param ctx 上下文
+   * @param groupID 群 ID
+   * @param userID 禁言对象 ID
+   * @param duration 禁言时长（秒）
+   */
+  export function memberBan(ctx: MsgContext, groupID: string, userID: string, duration: number): void;
+  /**
+   * 踢人
+   * @param ctx 上下文
+   * @param groupID 群 ID
+   * @param userID 踢出对象 ID
+   */
+  export function memberKick(ctx: MsgContext, groupID: string, userID: string): void;
+  /** 获取版本信息 */
   export function getVersion(): VersionDetailsType;
-  /** 获取骰娘的EndPoints   */
-  export function getEndPoints(): EndPointInfo[]
-
-  export function setPlayerGroupCard(ctx: MsgContext, tmpl: string): string
-  // 通过base64返回图像临时地址
-  export function base64ToImage(base64: string): string
-
-  /** 获取/修改 VM 变量 ，如 `$t`、`$g` */
-  export const vars: {
-    /** VM 中存在 key 且类型正确 返回 `[number,true]` ，否则返回 `[0,false]` */
-    intGet(ctx: MsgContext, key: string): [number, boolean];
-    /** 赋值 key 为 value 等价于指令 `text {key=value}` value 类型为数字 */
-    intSet(ctx: MsgContext, key: string, value: number): void;
-    /** VM 中存在 key 且类型正确 返回 `[string,true]` ，否则返回 `['',false]` */
-    strGet(ctx: MsgContext, key: string): [string, boolean];
-    /** 赋值 key 为 value 等价于指令 `text {key=value}` value 类型为字符串 */
-    strSet(ctx: MsgContext, key: string, value: string): void;
-  }
-
-  export const gameSystem: {
-    /** 添加一个规则模板，需要是JSON文本格式 */
-    newTemplate(data: string): unknown;
-    /** 添加一个规则模板，需要是YAML文本格式 */
-    newTemplateByYaml(data: string): unknown;
-  }
-
-
-  /** deck */
-  export interface deckResult {
-    /** 是否存在 */
-    "exists": boolean,
-    /** 错误信息 */
-    "err": string,
-    /** 抽牌结果 */
-    "result": string | null
-  }
-
-  export const deck: {
-    /**
-     * 抽牌函数
-     * @param ctx
-     * @param name 牌堆名
-     * @param isShuffle 是否放回
-     */
-    draw(ctx: MsgContext, name: string, isShuffle: boolean): deckResult
-  }
-
+  /** 获取骰子的所有 EndPoints（通信端点） */
+  export function getEndPoints(): EndPointInfo[];
 }


### PR DESCRIPTION
## 背景
更新 seal.d.ts 后类型检查报错 92 处：`registerXxxConfig` 未声明 group 参数（TS2554 ×91）、`CmdItemInfo.solve` 未声明 Promise 返回（TS2322 ×1）、`onMessageSend` 调用缺 flag 参数（TS2554 ×1）。

## 改动
- `types/seal.d.ts`：`registerStringConfig/IntConfig/FloatConfig/BoolConfig/TemplateConfig` 增加可选 `group?` 参数（对应 WebUI 二级页签）；`registerOptionConfig` 增加可选 `group?`；`CmdItemInfo.solve` 返回类型扩展为 `CmdExecuteResult | Promise<CmdExecuteResult>`
- `src/index.ts`：`ext.onMessageSend(ctx, msg)` 调用补上 flag 参数 `''`（与类型定义一致）

## 验证
- `npx tsc --noEmit` 0 错误；`npm run lint` / `npm run build` 通过