### PR TITLE
fix: 清理孤立 tool 消息（tool 之后没有对应 tool_calls 导致 API 报错）

### DIFF
--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -124,9 +124,30 @@ export async function handleMessages(ctx: seal.MsgContext, session: Session): Pr
         }
 
         if (toolCalls.length === 0) {
+            // assistant 的 tool_calls 全部被过滤时，同步删除其后跟随的 tool 消息，避免孤立
+            for (let j = i + 1; j < messages.length && messages[j].role === 'tool'; j++) {
+                messages.splice(j, 1);
+                j--;
+            }
             messages.splice(i, 1);
             i--;
         }
+    }
+
+    // 清理孤立 tool 消息：前面不存在对应 assistant tool_calls 的 tool 结果直接丢弃，
+    // 避免发送给 API 时出现 "role 'tool' 必须跟在对应 tool_calls 之后" 报错（如上下文被裁剪后残留）
+    const toolCallIdSet = new Set<string>();
+    for (const message of messages) {
+        const toolCalls = message.toolCalls || message.tool_calls;
+        if (message.role === 'assistant' && toolCalls) {
+            for (const tc of toolCalls) toolCallIdSet.add(tc.id);
+        }
+    }
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i];
+        if (message.role !== 'tool') continue;
+        const id = message.toolCallId || message.tool_call_id || '';
+        if (!toolCallIdSet.has(id)) messages.splice(i, 1);
     }
 
     return messages.map(message => ({


### PR DESCRIPTION
## 问题
对话中经常出现 API 报错：`messages with role 'tool' must be a response to a preceding message with 'tool_calls'`。

## 根因
`handleMessages` 过滤没有对应 tool 结果的 `tool_calls` 时，若 assistant 消息的 `tool_calls` 全部被过滤，会删除该 assistant 消息，但其后跟随的 `tool` 消息未被同步删除，形成孤立 tool 消息；上下文被裁剪（token 预算 / 轮数）等场景也可能残留孤立 tool 消息，发送给 API 即报错。

## 修复（src/utils/message.ts）
1. 删除被过滤空的 assistant 消息时，同步删除其后连续跟随的 `tool` 消息；
2. 增加一轮清理：删除所有前面不存在对应 `assistant.tool_calls` 的孤立 `tool` 消息。

## 验证
- `npx tsc --noEmit --strict` 0 错误；`npm run lint` / `npm run build` / `npm run smoke` 通过