### PR TITLE
chore: 移除 globalThis.http 旧依赖兜底，统一使用 ob11 网络连接依赖

### DIFF
--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -4,7 +4,7 @@ import { logger } from "../logger";
 import { MessageSegment } from "./string";
 
 export function getNet() {
-    const net = globalThis.net || globalThis.http;
+    const net = globalThis.net;
     if (!net) {
         logger.warning(`未找到ob11网络连接依赖`);
         return null;
@@ -13,7 +13,7 @@ export function getNet() {
 }
 
 export function netExists(): boolean {
-    const net = globalThis.net || globalThis.http;
+    const net = globalThis.net;
     return net !== null && net !== undefined;
 }
 


### PR DESCRIPTION
## 背景
旧 HTTP依赖（http_dependency.js）已废弃并删除，新实现为 `ob11网络连接依赖`（`globalThis.net`）。aiplugin4 的 `src/utils/ob11.ts` 中 `getNet()` / `netExists()` 仍保留 `globalThis.net || globalThis.http` 兜底。

## 改动（src/utils/ob11.ts）
- 移除 `globalThis.http` 兜底，统一只读取 `globalThis.net`；未安装 ob11 依赖时仍按原逻辑提示安装

## 验证
- `npx tsc --noEmit --strict` 0 错误
- `npm run build` 通过，产物 `dist/aiplugin4.js` 已无 `globalThis.http` 引用
- `npm run smoke` 通过（插件加载与对外 API 均正常）