### PR TITLE
feat: web_read 适配后端 /screenshot 接口（网页截图返回图片）

### DIFF
--- a/src/tool/tools/tool_web.ts
+++ b/src/tool/tools/tool_web.ts
@@ -1,6 +1,8 @@
 // 联网工具：搜索与网页阅读
 import Config from "../../config/config";
 import { logger } from "../../logger";
+import Image from "../../resource/image";
+import { generateId } from "../../utils/utils";
 import Tool from "../tool";
 
 export function registerWeb() {
@@ -88,13 +90,33 @@ export function registerWeb() {
         type: "function",
         function: {
             name: "web_read",
-            description: `读取网页内容`,
+            description: `读取网页内容或对网页截图。默认抓取网页标题/正文/链接；screenshot=true 时对网页截图并返回可发送的图片`,
             parameters: {
                 type: "object",
                 properties: {
                     url: {
                         type: "string",
-                        description: "需要读取内容的网页链接"
+                        description: "需要读取内容或截图的网页链接"
+                    },
+                    screenshot: {
+                        type: "boolean",
+                        description: "true 时对网页截图并返回图片，false（默认）时抓取网页文本内容"
+                    },
+                    width: {
+                        type: "integer",
+                        description: "截图视口宽度，默认 1680"
+                    },
+                    height: {
+                        type: "integer",
+                        description: "截图视口高度，默认 1000"
+                    },
+                    fullPage: {
+                        type: "boolean",
+                        description: "是否截取整页（长图），默认 false"
+                    },
+                    delay: {
+                        type: "integer",
+                        description: "页面加载完成后等待的毫秒数，默认 3000"
                     }
                 },
                 required: ["url"]
@@ -102,8 +124,41 @@ export function registerWeb() {
         }
     });
     tool.solve = async (_, __, ___, args) => {
-        const { url } = args;
+        const { url, screenshot = false, width, height, fullPage = false, delay } = args;
         const { WEB_READ: webReadUrl } = Config.backend;
+
+        if (screenshot) {
+            try {
+                logger.info(`网页截图: ${url}`);
+                const response = await fetch(`${webReadUrl}/screenshot`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify({ url, width, height, fullPage, delay })
+                });
+
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(`请求失败: ${JSON.stringify(data)}`);
+                }
+                if (data.status !== 'success' || !data.base64) {
+                    throw new Error(data.message || '截图失败');
+                }
+
+                const img = new Image();
+                img.imageId = `web_${generateId()}`;
+                img.base64 = data.base64;
+                img.format = 'png';
+                img.description = `网页截图<|img:${img.imageId}|>`;
+                Image.save(img);
+
+                return `截图成功，请使用<|img:${img.imageId}|>发送`;
+            } catch (error) {
+                logger.error("在web_read截图请求中出错：", error);
+                return `网页截图失败: ${error instanceof Error ? error.message : String(error)}`;
+            }
+        }
 
         try {
             logger.info(`读取网页内容: ${url}`);


### PR DESCRIPTION
## 背景
aiplugin4-backends 的 `web-read` 后端新增了 `POST /screenshot` 接口（Puppeteer 网页截图，返回 PNG base64），`web_read` 工具适配该接口，让 AI 可以直接对网页截图。

## 改动（src/tool/tools/tool_web.ts）
- `web_read` 新增 `screenshot` 参数：`true` 时调用 `POST {后端}/screenshot` 截图网页，`false`（默认）保持原有抓取标题/正文/链接逻辑
- 支持截图参数：`width`（默认 1680）、`height`（默认 1000）、`fullPage`（整页长图）、`delay`（加载后等待毫秒，默认 3000）
- 截图成功后将 base64 存为图片资源（`Image.save`），返回 `<|img:图片ID|>` 供 AI 直接发送，避免把整段 base64 塞进上下文

## 验证
- `npx tsc --noEmit --strict` 0 错误；`npm run lint` / `npm run build` 通过