### PR TITLE
docs: 4.13.4 发布准备（版本号/更新日志/README 徽章与文档同步）

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - 让你的骰娘活起来
 
 ![License](https://img.shields.io/badge/License-MIT-blue)
-![Version](https://img.shields.io/badge/Version-4.13.3-green)
+![Version](https://img.shields.io/badge/Version-4.13.4-green)
 
 ## 快速开始
 

--- a/docs/01-项目概览.md
+++ b/docs/01-项目概览.md
@@ -29,9 +29,9 @@ AI 骰娘4(`aiplugin4`)是运行在 SealDice 上的 JavaScript 插件,为骰娘�
 
 ## 版本信息
 
-- `src/config/static_config.ts` 中 `VERSION = "4.13.3"`,作者 `baiyu&错误`,插件名 `aiplugin4`。
+- `src/config/static_config.ts` 中 `VERSION = "4.13.4"`,作者 `baiyu&错误`,插件名 `aiplugin4`。
 - 开发遵循「分支 + squash PR」流程(见 [07-开发指南](07-开发指南.md));近期工作围绕:模型配置 TOML 化、Provider 统一请求(超时/重试/用量上报)、智能体编排重构、MCP/技能、日志治理、消息管线、配套后端独立仓库化等。
-- README 顶部徽章与 `VERSION` 保持一致（当前 4.13.3）(详见 [09-注意事项与常见问题](09-注意事项与常见问题.md))。
+- README 顶部徽章与 `VERSION` 保持一致（当前 4.13.4）(详见 [09-注意事项与常见问题](09-注意事项与常见问题.md))。
 
 ## 环境要求
 

--- a/docs/03-核心模块详解.md
+++ b/docs/03-核心模块详解.md
@@ -31,7 +31,7 @@
 
 ### static_config.ts(静态常量)
 
-- `VERSION`(当前 4.13.3)、`AUTHOR`、`NAME`、`STORAGE_VERSION`、`CONFIG_CACHE_TTL`、`CQ_TYPES_ALLOW`。
+- `VERSION`(当前 4.13.4)、`AUTHOR`、`NAME`、`STORAGE_VERSION`、`CONFIG_CACHE_TTL`、`CQ_TYPES_ALLOW`。
 - `PRIVILEGE_LEVEL_MAP`:master=100 / whitelist=70 / owner=60 / admin=50 / inviter=40 / user=0 / blacklist=-30。
 - `HELP_MAP`、`ALIAS_MAP`(命令别名表)、`FACE_MAP`(QQ 表情编号 → 名称)。
 - `PROVIDER_MAP`:10 家厂商的 OpenAI 兼容 base_url。

--- a/docs/09-注意事项与常见问题.md
+++ b/docs/09-注意事项与常见问题.md
@@ -14,7 +14,7 @@
 
 ## 代码中的已知不一致
 
-- `src/config/static_config.ts` 的 `VERSION` 与 `src/update.ts` 的 `updateInfo` 最新条目需保持一致（当前 4.13.3）；`checkUpdate` 按 `VERSION` 比较输出对应更新日志。
+- `src/config/static_config.ts` 的 `VERSION` 与 `src/update.ts` 的 `updateInfo` 最新条目需保持一致（当前 4.13.4）；`checkUpdate` 按 `VERSION` 比较输出对应更新日志。
 - `package.json` 的 `main`/`typings` 指向 `build/index.js`/`build/index.d.ts`,但实际构建产物是 `dist/aiplugin4.js`(esbuild),`build/` 目录是陈旧的 tsc 输出,与构建流程无关。
 - `engines.node >= 10` 是模板遗留,实际构建依赖 esbuild,建议使用较新 Node。
 - `sub_cmd/sample.ts` 与 `agent/agents/samples.ts` 是开发示例,未注册到运行时。

--- a/header.txt
+++ b/header.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AI骰娘4
 // @author       错误、白鱼
-// @version      4.13.3
+// @version      4.13.4
 // @description  适用于大部分OpenAI API兼容格式AI的模型插件，测试环境为 Deepseek AI (https://platform.deepseek.com/)，用于与 AI 进行对话，并根据特定关键词触发回复。使用.ai help查看使用方法。具体配置查看插件配置项。\nopenai标准下的function calling功能已进行适配，选用模型若不支持该功能，可以开启迁移到提示词工程的开关，即可使用调用函数功能。\n交流答疑QQ群：143412516
 // @timestamp    1733387279
 // 2024-12-05 16:27:59

--- a/sealpack/info.toml
+++ b/sealpack/info.toml
@@ -7,7 +7,7 @@ format_version = "1.0.0"
 [package]
 id = "error2913/aiplugin4"
 name = "AI骰娘4"
-version = "4.13.3"
+version = "4.13.4"
 authors = ["错误、白鱼"]
 license = "MIT"
 description = "适用于大部分 OpenAI API 兼容格式 AI 的 Sealdice 模型插件，支持对话、记忆、工具调用、MCP/Skills 等。"

--- a/src/config/static_config.ts
+++ b/src/config/static_config.ts
@@ -1,5 +1,5 @@
 // 静态常量：版本/作者/模型映射表/权限等级/别名/表情表等
-export const VERSION = "4.13.3";
+export const VERSION = "4.13.4";
 export const AUTHOR = "baiyu&错误";
 export const NAME = "aiplugin4";
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,15 @@
 // 版本更新日志（updateInfo），供启动时展示更新说明
 // 版本更新日志，格式为 "版本号": "更新内容"，版本号格式为 "x.y.z"，按照时间顺序从新到旧排列。
 export const updateInfo: { [version: string]: string } = {
+    "4.13.4": `## 新功能
+- 对外 API（globalThis.aiplugin4）新增三种模型直接调用：chatMessages（传入 OpenAI 风格 messages 数组调用对话模型）、imageToText（识图）、embed（文本向量），其他插件可构建消息直接拿回复
+- web_read 工具新增网页截图能力（screenshot=true，支持宽高/整页/延时），截图返回图片可直接发送
+## 优化
+- seal.d.ts 类型补齐（配置注册 group 参数、async solve），启用 strict 类型检查
+- 移除 globalThis.http 旧依赖兜底，统一使用 ob11 网络连接依赖
+- 新增 AGENT.md 代理协作速查文档
+## 修复
+- 修复工具调用后孤立 tool 消息导致的 API 报错（tool 消息缺少对应 tool_calls）`,
     "4.13.3": `## 新功能
 - 新增 run_command 工具：读取海豹扩展指令表列出可用指令（action=list 不含帮助），并可调用白名单内的海豹指令（action=call，开启「是否允许调用所有指令」后可调用任意指令）；配套 get_cmd_help 工具按名查看指令帮助
 - 新增「可调用指令白名单」「是否允许调用所有指令」配置（工具页签）；指令技能（今日人品/COC 模组/属性展示/检定/san检定）统一改为通过 run_command 调用


### PR DESCRIPTION
## 版本推进 4.13.3 → 4.13.4
- `src/config/static_config.ts` 的 `VERSION`、`header.txt` 的 `@version`、`sealpack/info.toml` 的 `version`
- `src/update.ts` 新增 4.13.4 更新日志：对外 API 三种模型直接调用（chatMessages/imageToText/embed）、web_read 网页截图、seal.d.ts 类型补齐与 strict 检查、移除 globalThis.http 兜底、孤立 tool 消息修复、AGENT.md

## 文档
- README 版本徽章、docs/01/03/09 版本引用同步为 4.13.4

## 验证
- `npx tsc --noEmit --strict` 0 错误；lint / build 通过；`node scripts/release-notes.js 4.13.4` 可正常提取更新日志