### PR TITLE
feat: 接收卡片/视频/音乐/文件/语音/合并转发消息（走 ob11 事件分发）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,12 @@ function main() {
   //接受的指令
   ext.onCommandReceived = (ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs) => {
     try {
-      MessagePipeline.handleCommand(ctx, msg, cmdArgs);
+      const p = MessagePipeline.handleCommand(ctx, msg, cmdArgs);
+      if (p && typeof (p as Promise<void>).catch === 'function') {
+        (p as Promise<void>).catch((e: any) => {
+          logger.error(`指令消息处理异步出错:${e instanceof Error ? e.message : String(e)}`);
+        });
+      }
     } catch (e) {
       logger.error(`指令消息处理出错，错误信息:${e instanceof Error ? e.message : String(e)}`);
     }
@@ -93,7 +98,12 @@ function main() {
   //骰子发送的消息
   ext.onMessageSend = (ctx: seal.MsgContext, msg: seal.Message) => {
     try {
-      MessagePipeline.handleBotMessage(ctx, msg);
+      const p = MessagePipeline.handleBotMessage(ctx, msg);
+      if (p && typeof (p as Promise<void>).catch === 'function') {
+        (p as Promise<void>).catch((e: any) => {
+          logger.error(`获取发送消息处理异步出错:${e instanceof Error ? e.message : String(e)}`);
+        });
+      }
     } catch (e) {
       logger.error(`获取发送消息处理出错，错误信息:${e instanceof Error ? e.message : String(e)}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,12 +84,7 @@ function main() {
   //接受的指令
   ext.onCommandReceived = (ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs) => {
     try {
-      const p = MessagePipeline.handleCommand(ctx, msg, cmdArgs);
-      if (p && typeof (p as Promise<void>).catch === 'function') {
-        (p as Promise<void>).catch((e: any) => {
-          logger.error(`指令消息处理异步出错:${e instanceof Error ? e.message : String(e)}`);
-        });
-      }
+      MessagePipeline.handleCommand(ctx, msg, cmdArgs);
     } catch (e) {
       logger.error(`指令消息处理出错，错误信息:${e instanceof Error ? e.message : String(e)}`);
     }
@@ -98,12 +93,7 @@ function main() {
   //骰子发送的消息
   ext.onMessageSend = (ctx: seal.MsgContext, msg: seal.Message) => {
     try {
-      const p = MessagePipeline.handleBotMessage(ctx, msg);
-      if (p && typeof (p as Promise<void>).catch === 'function') {
-        (p as Promise<void>).catch((e: any) => {
-          logger.error(`获取发送消息处理异步出错:${e instanceof Error ? e.message : String(e)}`);
-        });
-      }
+      MessagePipeline.handleBotMessage(ctx, msg);
     } catch (e) {
       logger.error(`获取发送消息处理出错，错误信息:${e instanceof Error ? e.message : String(e)}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ function main() {
 
   registerCmd();
   PrivilegeManager.reviveCmdPriv();
+  // ob11 依赖存在时订阅其事件分发，接收核心原生 milky 路径过滤掉的卡片/视频/文件/合并转发等段
+  MessagePipeline.subscribeOb11Receive();
 
   // 存储版本标记：结构变更时递增，供后续迁移使用
   const storedVersion = parseInt(ext.storageGet('storage_version') || '0');

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger";
 import { getSession } from "./session/session_service";
 import Tool from "./tool/tool";
 import { triggerConditionMap } from "./tool/tools/tool_trigger";
-import { expandForwardMessage } from "./utils/ob11";
+import { expandForwardMessage, getGroupFileDownloadUrl, getPrivateFileDownloadUrl } from "./utils/ob11";
 import { MessageSegment, transformTextToArray } from "./utils/string";
 
 /** 解析 QQ 卡片消息（CQ:json 的 data 字段），提取标题/描述/链接等可读文本 */
@@ -34,9 +34,17 @@ function parseCardToText(raw: string): string {
 }
 
 export class MessagePipeline {
+    /** 统一消息形态：CQ 码字符串或 OneBot 消息段数组 → MessageSegment[] */
+    private static toMessageArray(message: string | any[] | any): MessageSegment[] {
+        if (typeof message === 'string') return transformTextToArray(message);
+        if (Array.isArray(message)) return message as MessageSegment[];
+        return [];
+    }
+
     /** 展开消息中的特殊段（合并转发走 ob11 / 文件 / 卡片），返回替换后的消息段 */
-    private static async expandSpecialSegments(epId: string, segs: MessageSegment[]): Promise<MessageSegment[]> {
+    private static async expandSpecialSegments(ctx: seal.MsgContext, segs: MessageSegment[]): Promise<MessageSegment[]> {
         const result: MessageSegment[] = [];
+        const epId = ctx.endPoint.userId;
         for (const seg of segs) {
             switch (seg.type) {
                 case 'forward': {
@@ -49,7 +57,15 @@ export class MessagePipeline {
                 }
                 case 'file': {
                     const name = (seg.data && seg.data.file) || '';
-                    const url = (seg.data && seg.data.url) || '';
+                    const fileId = (seg.data && seg.data.file) || '';
+                    const busid = (seg.data && seg.data.busid) || '';
+                    let url = (seg.data && seg.data.url) || '';
+                    // 缺少下载链接时走 ob11 依赖获取（与合并转发同路径）
+                    if (!url && fileId) {
+                        url = ctx.isPrivate
+                            ? await getPrivateFileDownloadUrl(epId, ctx.player!.userId, fileId, busid)
+                            : await getGroupFileDownloadUrl(epId, ctx.group!.groupId, fileId, busid);
+                    }
                     result.push({
                         type: 'text',
                         data: { text: `【文件】${name}${url ? ` ${url}` : ''}` }
@@ -109,11 +125,11 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = transformTextToArray(message);
+        let messageArray = this.toMessageArray(message);
 
         // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段后再走后续过滤/触发
         if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
+            messageArray = await this.expandSpecialSegments(ctx, messageArray);
         }
 
         // 忽略条件（豹语表达式）命中时直接忽略
@@ -219,11 +235,11 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = transformTextToArray(message);
+        let messageArray = this.toMessageArray(message);
 
         // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
         if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
+            messageArray = await this.expandSpecialSegments(ctx, messageArray);
         }
 
         const CQTypes = messageArray.filter(item => item.type !== 'text').map(item => item.type);
@@ -245,11 +261,11 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = transformTextToArray(message);
+        let messageArray = this.toMessageArray(message);
 
         // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
         if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
+            messageArray = await this.expandSpecialSegments(ctx, messageArray);
         }
 
         session.tool.listen.resolve?.(message); // 将消息传递给监听工具

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,22 +9,71 @@ import { triggerConditionMap } from "./tool/tools/tool_trigger";
 import { expandForwardMessage } from "./utils/ob11";
 import { MessageSegment, transformTextToArray } from "./utils/string";
 
+/** 解析 QQ 卡片消息（CQ:json 的 data 字段），提取标题/描述/链接等可读文本 */
+function parseCardToText(raw: string): string {
+    if (!raw) return '[卡片消息]';
+
+    let obj: any = null;
+    try {
+        obj = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    } catch (_e) {
+        return `[卡片消息] ${raw.slice(0, 200)}`;
+    }
+
+    const str = (v: any): string => (typeof v === 'string' && v.trim()) ? v.trim() : '';
+
+    // 常见卡片结构：view / meta.news / meta.detail 等
+    const view = (obj && (obj.view || (obj.meta && (obj.meta.news || obj.meta.detail || obj.meta.article)))) || obj || {};
+    const title = str(view.title) || str(obj.desc) || str(view.desc) || '';
+    const desc = str(view.desc) || str(view.summary) || (view.news && str(view.news.desc)) || '';
+    const url = str(view.url) || str(view.jumpUrl) || (view.news && str(view.news.jumpUrl)) || (view.detail && str(view.detail.jumpUrl)) || '';
+
+    const parts = [title, desc].filter(Boolean);
+    if (parts.length === 0) return '[卡片消息]';
+    return `【卡片】${parts.join('\n')}${url ? `\n${url}` : ''}`;
+}
+
 export class MessagePipeline {
-    /** 展开消息中的合并转发段（走 ob11 get_forward_msg，支持嵌套），返回替换后的消息段 */
-    private static async expandForwardSegments(epId: string, segs: MessageSegment[]): Promise<MessageSegment[]> {
+    /** 展开消息中的特殊段（合并转发走 ob11 / 文件 / 卡片），返回替换后的消息段 */
+    private static async expandSpecialSegments(epId: string, segs: MessageSegment[]): Promise<MessageSegment[]> {
         const result: MessageSegment[] = [];
         for (const seg of segs) {
-            if (seg.type === 'forward') {
-                const text = await expandForwardMessage(epId, (seg.data && seg.data.id) || '');
-                result.push({
-                    type: 'text',
-                    data: { text: text ? `【合并转发】\n${text}` : '[合并转发消息，展开失败]' }
-                });
-            } else {
-                result.push(seg);
+            switch (seg.type) {
+                case 'forward': {
+                    const text = await expandForwardMessage(epId, (seg.data && seg.data.id) || '');
+                    result.push({
+                        type: 'text',
+                        data: { text: text ? `【合并转发】\n${text}` : '[合并转发消息，展开失败]' }
+                    });
+                    break;
+                }
+                case 'file': {
+                    const name = (seg.data && seg.data.file) || '';
+                    const url = (seg.data && seg.data.url) || '';
+                    result.push({
+                        type: 'text',
+                        data: { text: `【文件】${name}${url ? ` ${url}` : ''}` }
+                    });
+                    break;
+                }
+                case 'json': {
+                    result.push({
+                        type: 'text',
+                        data: { text: parseCardToText(seg.data && seg.data.data) }
+                    });
+                    break;
+                }
+                default: {
+                    result.push(seg);
+                }
             }
         }
         return result;
+    }
+
+    /** 判断消息段是否需要展开（合并转发/文件/卡片） */
+    private static hasSpecialSegment(segs: MessageSegment[]): boolean {
+        return segs.some(seg => seg.type === 'forward' || seg.type === 'file' || seg.type === 'json');
     }
 
     /** 非指令消息：过滤后进入会话，由智能体决定是否触发回复 */
@@ -62,9 +111,9 @@ export class MessagePipeline {
         const message = msg.message;
         let messageArray = transformTextToArray(message);
 
-        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段后再走后续过滤/触发
-        if (messageArray.some(seg => seg.type === 'forward')) {
-            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段后再走后续过滤/触发
+        if (this.hasSpecialSegment(messageArray)) {
+            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
         }
 
         // 忽略条件（豹语表达式）命中时直接忽略
@@ -172,9 +221,9 @@ export class MessagePipeline {
         const message = msg.message;
         let messageArray = transformTextToArray(message);
 
-        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段
-        if (messageArray.some(seg => seg.type === 'forward')) {
-            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
+        if (this.hasSpecialSegment(messageArray)) {
+            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
         }
 
         const CQTypes = messageArray.filter(item => item.type !== 'text').map(item => item.type);
@@ -198,9 +247,9 @@ export class MessagePipeline {
         const message = msg.message;
         let messageArray = transformTextToArray(message);
 
-        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段
-        if (messageArray.some(seg => seg.type === 'forward')) {
-            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
+        if (this.hasSpecialSegment(messageArray)) {
+            messageArray = await this.expandSpecialSegments(ctx.endPoint.userId, messageArray);
         }
 
         session.tool.listen.resolve?.(message); // 将消息传递给监听工具

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,45 +1,17 @@
 // 消息管线：接收 → 过滤（忽略/触发）→ 会话 → 智能体，统一处理非指令/指令/机器人自身消息
 import { BlockManager } from "./block";
-import Config from "./config/config";
+import Config, { ext } from "./config/config";
 import { CQ_TYPES_ALLOW } from "./config/static_config";
 import { logger } from "./logger";
 import { getSession } from "./session/session_service";
 import Tool from "./tool/tool";
 import { triggerConditionMap } from "./tool/tools/tool_trigger";
 import { expandForwardMessage } from "./utils/ob11";
-import { MessageSegment, transformTextToArray } from "./utils/string";
+import { createCtx, createMsg } from "./utils/seal";
+import { MessageSegment, parseCardToText, parseMusicToText, transformTextToArray } from "./utils/string";
 
-/** 解析 QQ 卡片消息（CQ:json 的 data 字段），提取标题/描述/链接等可读文本 */
-function parseCardToText(raw: string): string {
-    if (!raw) return '[卡片消息]';
-
-    let obj: any = null;
-    try {
-        obj = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    } catch (_e) {
-        return `[卡片消息] ${raw.slice(0, 200)}`;
-    }
-
-    const str = (v: any): string => (typeof v === 'string' && v.trim()) ? v.trim() : '';
-
-    // 常见卡片结构：view / meta.news / meta.detail 等
-    const view = (obj && (obj.view || (obj.meta && (obj.meta.news || obj.meta.detail || obj.meta.article)))) || obj || {};
-    const title = str(view.title) || str(obj.desc) || str(view.desc) || '';
-    const desc = str(view.desc) || str(view.summary) || (view.news && str(view.news.desc)) || '';
-    const url = str(view.url) || str(view.jumpUrl) || (view.news && str(view.news.jumpUrl)) || (view.detail && str(view.detail.jumpUrl)) || '';
-
-    const parts = [title, desc].filter(Boolean);
-    if (parts.length === 0) return '[卡片消息]';
-    return `【卡片】${parts.join('\n')}${url ? `\n${url}` : ''}`;
-}
-
-/** 音乐段转可读文本（data 为 qq/163 id 或 custom 对象） */
-function parseMusicToText(data: any): string {
-    if (data && data.title) return `【音乐】${data.title}`;
-    const type = data && data.type ? String(data.type) : '';
-    const id = data && data.id ? String(data.id) : '';
-    return `【音乐】${type}${id ? ` ${id}` : ''}`;
-}
+/** 海豹核心原生 milky 接收路径会过滤掉的段类型，只能通过 ob11 依赖的事件分发（milky → OB11 转接）收到 */
+const OB11_EXTRA_SEGMENT_TYPES = new Set(['json', 'video', 'file', 'node', 'forward', 'music', 'xml', 'markdown', 'market_face']);
 
 export class MessagePipeline {
     /** ob11 数组消息段 → MessageSegment[]：把卡片/视频/音乐/文件/消息节点/合并转发展开为文本段，其余段保留 */
@@ -55,7 +27,8 @@ export class MessagePipeline {
                     break;
                 }
                 case 'file': {
-                    result.push({ type: 'text', data: { text: `【文件】${data.file || ''}` } });
+                    // milky 转接与 NapCat 的 file 段字段略有差异（file/name/file_id），统一取可用值
+                    result.push({ type: 'text', data: { text: `【文件】${data.name || data.file || data.file_id || ''}` } });
                     break;
                 }
                 case 'video': {
@@ -87,6 +60,9 @@ export class MessagePipeline {
     /** 消息节点（node）转可读文本：完整节点递归内容，仅 id 时走 ob11 获取 */
     private static async parseNodeToText(ctx: seal.MsgContext, data: any): Promise<string> {
         const name = (data && (data.nickname || data.name)) || (data && data.user_id ? `用户${data.user_id}` : '');
+        if (data && typeof data.content === 'string') {
+            return `${name}: ${data.content}`;
+        }
         if (data && Array.isArray(data.content)) {
             const segs = await this.expandOb11Segments(ctx, data.content);
             let text = '';
@@ -100,6 +76,60 @@ export class MessagePipeline {
             return text ? `${name}:\n${text}` : `【消息节点】${name}`;
         }
         return `【消息节点】${name}`;
+    }
+
+    /** 订阅 ob11 网络连接依赖的事件分发：核心原生 milky 路径会丢弃视频/文件/卡片/合并转发等段，
+     *  这些段只有依赖的 OneBot 事件流（milky → OB11 转接）能拿到，在此接入并走同一套非指令管线 */
+    static subscribeOb11Receive(): void {
+        const net = (globalThis as any).net;
+        if (!net || typeof net.getEventDispatcher !== 'function') return;
+        net.getEventDispatcher(ext).then((ed: any) => {
+            ed.onMessageEvent = async (_epId: string, event: any) => {
+                try {
+                    await MessagePipeline.handleOb11Event(event);
+                } catch (e) {
+                    logger.error(`ob11 事件消息处理出错:${e instanceof Error ? e.message : String(e)}`);
+                }
+            };
+        }).catch((e: any) => {
+            logger.error(`订阅 ob11 事件分发失败:${e instanceof Error ? e.message : String(e)}`);
+        });
+    }
+
+    /** ob11 事件消息（OneBot 消息段数组）：仅处理核心原生路径收不到的段类型，避免与核心回调重复处理 */
+    private static async handleOb11Event(event: any): Promise<void> {
+        if (!event || event.post_type !== 'message') return;
+        const message = event.message;
+        if (!Array.isArray(message)) return;
+        if (event.user_id === event.self_id) return; // 机器人自己的消息（核心原生路径会忽略，这里保持一致）
+        if (!message.some((seg: any) => seg && OB11_EXTRA_SEGMENT_TYPES.has(seg.type))) return;
+
+        // 按端点解析平台前缀（默认 QQ），并构造与核心回调一致的 ctx/msg
+        const eps = seal.getEndPoints();
+        let epId = `QQ:${event.self_id}`;
+        for (const ep of eps) {
+            if (ep.userId === epId) break;
+            if (ep.userId.endsWith(`:${event.self_id}`)) epId = ep.userId;
+        }
+        const prefix = epId.includes(':') ? epId.slice(0, epId.indexOf(':')) : 'QQ';
+        const uid = `${prefix}:${event.user_id}`;
+        const isPrivate = event.message_type !== 'group';
+        const gid = isPrivate ? '' : `${prefix}-Group:${event.group_id}`;
+
+        const msg = createMsg(isPrivate ? 'private' : 'group', uid, gid);
+        msg.platform = prefix;
+        msg.message = message as any; // 消息段数组，交给 expandOb11Segments 展开
+        msg.time = event.time || 0;
+        msg.rawId = event.message_id ?? 0;
+        msg.sender.nickname = (event.sender && (event.sender.card || event.sender.nickname)) || '';
+        msg.sender.userId = uid;
+
+        const ctx = createCtx(epId, msg);
+        if (!ctx) {
+            logger.warning(`ob11 事件消息未找到通信端点: ${epId}，跳过`);
+            return;
+        }
+        await MessagePipeline.handleNonCommand(ctx, msg);
     }
 
     /** 非指令消息：过滤后进入会话，由智能体决定是否触发回复 */
@@ -140,6 +170,10 @@ export class MessagePipeline {
         const messageArray = Array.isArray(message)
             ? await this.expandOb11Segments(ctx, message)
             : transformTextToArray(message);
+        // 正则匹配统一使用可读文本：原生路径保持原字符串，数组路径用展开后的文本
+        const messageText = Array.isArray(message)
+            ? messageArray.map(item => item.type === 'text' ? ((item.data && item.data.text) || '') : `[${item.type}]`).join('')
+            : message;
 
         // 忽略条件（豹语表达式）命中时直接忽略
         if (parseInt(seal.format(ctx, `{${IGNORE_CONDITION}}`)) === 1) {
@@ -147,8 +181,8 @@ export class MessagePipeline {
             return;
         }
 
-        if (ignoreRegex.test(message)) {
-            logger.info(`非指令消息忽略:${message}`);
+        if (ignoreRegex.test(messageText)) {
+            logger.info(`非指令消息忽略:${messageText}`);
             return;
         }
 
@@ -159,7 +193,7 @@ export class MessagePipeline {
             session.context.timer = null;
 
             // 非指令消息触发（受会话开关控制）
-            if (session.setting.regexTrigger && triggerRegex.test(message)) {
+            if (session.setting.regexTrigger && triggerRegex.test(messageText)) {
                 const fmtCondition = parseInt(seal.format(ctx, `{${triggerCondition}}`));
                 if (fmtCondition === 1) {
                     return session.handleReceipt(ctx, msg, messageArray)
@@ -175,7 +209,7 @@ export class MessagePipeline {
                     let keywordMatched = true;
                     if (condition.keyword) {
                         try {
-                            keywordMatched = new RegExp(condition.keyword).test(message);
+                            keywordMatched = new RegExp(condition.keyword).test(messageText);
                         } catch (e) {
                             logger.error(`触发关键词正则错误，已忽略该条件:${condition.keyword}，错误信息:${e instanceof Error ? e.message : String(e)}`);
                             keywordMatched = false;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger";
 import { getSession } from "./session/session_service";
 import Tool from "./tool/tool";
 import { triggerConditionMap } from "./tool/tools/tool_trigger";
-import { expandForwardMessage, getGroupFileDownloadUrl, getPrivateFileDownloadUrl } from "./utils/ob11";
+import { expandForwardMessage } from "./utils/ob11";
 import { MessageSegment, transformTextToArray } from "./utils/string";
 
 /** 解析 QQ 卡片消息（CQ:json 的 data 字段），提取标题/描述/链接等可读文本 */
@@ -33,63 +33,73 @@ function parseCardToText(raw: string): string {
     return `【卡片】${parts.join('\n')}${url ? `\n${url}` : ''}`;
 }
 
-export class MessagePipeline {
-    /** 统一消息形态：CQ 码字符串或 OneBot 消息段数组 → MessageSegment[] */
-    private static toMessageArray(message: string | any[] | any): MessageSegment[] {
-        if (typeof message === 'string') return transformTextToArray(message);
-        if (Array.isArray(message)) return message as MessageSegment[];
-        return [];
-    }
+/** 音乐段转可读文本（data 为 qq/163 id 或 custom 对象） */
+function parseMusicToText(data: any): string {
+    if (data && data.title) return `【音乐】${data.title}`;
+    const type = data && data.type ? String(data.type) : '';
+    const id = data && data.id ? String(data.id) : '';
+    return `【音乐】${type}${id ? ` ${id}` : ''}`;
+}
 
-    /** 展开消息中的特殊段（合并转发走 ob11 / 文件 / 卡片），返回替换后的消息段 */
-    private static async expandSpecialSegments(ctx: seal.MsgContext, segs: MessageSegment[]): Promise<MessageSegment[]> {
+export class MessagePipeline {
+    /** ob11 数组消息段 → MessageSegment[]：把卡片/视频/音乐/文件/消息节点/合并转发展开为文本段，其余段保留 */
+    private static async expandOb11Segments(ctx: seal.MsgContext, segs: any[]): Promise<MessageSegment[]> {
         const result: MessageSegment[] = [];
         const epId = ctx.endPoint.userId;
         for (const seg of segs) {
+            if (!seg || typeof seg !== 'object') continue;
+            const data = seg.data || {};
             switch (seg.type) {
+                case 'json': {
+                    result.push({ type: 'text', data: { text: parseCardToText(data.data) } });
+                    break;
+                }
+                case 'file': {
+                    result.push({ type: 'text', data: { text: `【文件】${data.file || ''}` } });
+                    break;
+                }
+                case 'video': {
+                    result.push({ type: 'text', data: { text: `【视频】${data.file || ''}` } });
+                    break;
+                }
+                case 'music': {
+                    result.push({ type: 'text', data: { text: parseMusicToText(data) } });
+                    break;
+                }
+                case 'node': {
+                    result.push({ type: 'text', data: { text: await MessagePipeline.parseNodeToText(ctx, data) } });
+                    break;
+                }
                 case 'forward': {
-                    const text = await expandForwardMessage(epId, (seg.data && seg.data.id) || '');
+                    const text = await expandForwardMessage(epId, data.id || data.file || '');
                     result.push({
                         type: 'text',
                         data: { text: text ? `【合并转发】\n${text}` : '[合并转发消息，展开失败]' }
                     });
                     break;
                 }
-                case 'file': {
-                    const name = (seg.data && seg.data.file) || '';
-                    const fileId = (seg.data && seg.data.file) || '';
-                    const busid = (seg.data && seg.data.busid) || '';
-                    let url = (seg.data && seg.data.url) || '';
-                    // 缺少下载链接时走 ob11 依赖获取（与合并转发同路径）
-                    if (!url && fileId) {
-                        url = ctx.isPrivate
-                            ? await getPrivateFileDownloadUrl(epId, ctx.player!.userId, fileId, busid)
-                            : await getGroupFileDownloadUrl(epId, ctx.group!.groupId, fileId, busid);
-                    }
-                    result.push({
-                        type: 'text',
-                        data: { text: `【文件】${name}${url ? ` ${url}` : ''}` }
-                    });
-                    break;
-                }
-                case 'json': {
-                    result.push({
-                        type: 'text',
-                        data: { text: parseCardToText(seg.data && seg.data.data) }
-                    });
-                    break;
-                }
-                default: {
-                    result.push(seg);
-                }
+                default: result.push(seg as MessageSegment);
             }
         }
         return result;
     }
 
-    /** 判断消息段是否需要展开（合并转发/文件/卡片） */
-    private static hasSpecialSegment(segs: MessageSegment[]): boolean {
-        return segs.some(seg => seg.type === 'forward' || seg.type === 'file' || seg.type === 'json');
+    /** 消息节点（node）转可读文本：完整节点递归内容，仅 id 时走 ob11 获取 */
+    private static async parseNodeToText(ctx: seal.MsgContext, data: any): Promise<string> {
+        const name = (data && (data.nickname || data.name)) || (data && data.user_id ? `用户${data.user_id}` : '');
+        if (data && Array.isArray(data.content)) {
+            const segs = await this.expandOb11Segments(ctx, data.content);
+            let text = '';
+            for (const s of segs) {
+                text += s.type === 'text' ? ((s.data && s.data.text) || '') : `[${s.type}]`;
+            }
+            return `${name}: ${text}`;
+        }
+        if (data && data.id) {
+            const text = await expandForwardMessage(ctx.endPoint.userId, String(data.id));
+            return text ? `${name}:\n${text}` : `【消息节点】${name}`;
+        }
+        return `【消息节点】${name}`;
     }
 
     /** 非指令消息：过滤后进入会话，由智能体决定是否触发回复 */
@@ -125,12 +135,11 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = this.toMessageArray(message);
-
-        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段后再走后续过滤/触发
-        if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx, messageArray);
-        }
+        // ob11 网络连接依赖以 OneBot 消息段数组传入时，走独立解析（卡片/视频/音乐/文件/消息节点/合并转发）；
+        // 海豹原生 CQ 码字符串路径保持不变
+        const messageArray = Array.isArray(message)
+            ? await this.expandOb11Segments(ctx, message)
+            : transformTextToArray(message);
 
         // 忽略条件（豹语表达式）命中时直接忽略
         if (parseInt(seal.format(ctx, `{${IGNORE_CONDITION}}`)) === 1) {
@@ -219,7 +228,7 @@ export class MessagePipeline {
     }
 
     /** 指令消息：记录 cmdArgs，并按配置决定是否写入会话上下文 */
-    static async handleCommand(ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs): Promise<void> {
+    static handleCommand(ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs): void {
         if (Tool.cmdArgs === null) {
             Tool.cmdArgs = cmdArgs;
         }
@@ -235,12 +244,7 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = this.toMessageArray(message);
-
-        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
-        if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx, messageArray);
-        }
+        const messageArray = transformTextToArray(message);
 
         const CQTypes = messageArray.filter(item => item.type !== 'text').map(item => item.type);
         if (CQTypes.length === 0 || CQTypes.every(item => CQ_TYPES_ALLOW.includes(item))) {
@@ -252,7 +256,7 @@ export class MessagePipeline {
     }
 
     /** 机器人自身发送的消息：转发给监听工具，并按配置决定是否记录上下文 */
-    static async handleBotMessage(ctx: seal.MsgContext, msg: seal.Message): Promise<void> {
+    static handleBotMessage(ctx: seal.MsgContext, msg: seal.Message): void {
         const uid = ctx.player!.userId;
         const gid = ctx.group!.groupId;
         const sid = ctx.isPrivate ? uid : gid;
@@ -261,12 +265,7 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        let messageArray = this.toMessageArray(message);
-
-        // 展开特殊段（合并转发走 ob11 / 文件 / 卡片），替换为可读文本段
-        if (this.hasSpecialSegment(messageArray)) {
-            messageArray = await this.expandSpecialSegments(ctx, messageArray);
-        }
+        const messageArray = transformTextToArray(message);
 
         session.tool.listen.resolve?.(message); // 将消息传递给监听工具
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -86,28 +86,51 @@ export class MessagePipeline {
     /** 订阅 ob11 网络连接依赖的事件分发：核心原生 milky 路径会丢弃视频/文件/卡片/合并转发等段，
      *  这些段只有依赖的 OneBot 事件流（milky → OB11 转接）能拿到，在此接入并走同一套非指令管线 */
     static subscribeOb11Receive(): void {
-        const net = (globalThis as any).net;
-        if (!net || typeof net.getEventDispatcher !== 'function') return;
-        net.getEventDispatcher(ext).then((ed: any) => {
-            ed.onMessageEvent = async (_epId: string, event: any) => {
-                try {
-                    await MessagePipeline.handleOb11Event(event);
-                } catch (e) {
-                    logger.error(`ob11 事件消息处理出错:${e instanceof Error ? e.message : String(e)}`);
+        const trySubscribe = (attempt: number): void => {
+            const net = (globalThis as any).net;
+            if (!net || typeof net.getEventDispatcher !== 'function') {
+                if (attempt < 10) {
+                    // ob11 依赖可能在 aiplugin4 之后加载，轮询等待就绪
+                    setTimeout(() => trySubscribe(attempt + 1), 3000);
+                } else {
+                    logger.info('[debug] 未找到 ob11 网络连接依赖，跳过 ob11 额外消息接收订阅');
                 }
-            };
-        }).catch((e: any) => {
-            logger.error(`订阅 ob11 事件分发失败:${e instanceof Error ? e.message : String(e)}`);
-        });
+                return;
+            }
+            net.getEventDispatcher(ext).then((ed: any) => {
+                ed.onMessageEvent = async (_epId: string, event: any) => {
+                    try {
+                        await MessagePipeline.handleOb11Event(event);
+                    } catch (e) {
+                        logger.error(`ob11 事件消息处理出错:${e instanceof Error ? e.message : String(e)}`);
+                    }
+                };
+                logger.info('[debug] 已订阅 ob11 事件分发，额外接收卡片/视频/音乐/文件/语音/合并转发等消息段');
+            }).catch((e: any) => {
+                logger.error(`订阅 ob11 事件分发失败:${e instanceof Error ? e.message : String(e)}`);
+            });
+        };
+        trySubscribe(0);
     }
 
     /** ob11 事件消息（OneBot 消息段数组）：仅处理核心原生路径收不到的段类型，避免与核心回调重复处理 */
     private static async handleOb11Event(event: any): Promise<void> {
         if (!event || event.post_type !== 'message') return;
         const message = event.message;
-        if (!Array.isArray(message)) return;
-        if (event.user_id === event.self_id) return; // 机器人自己的消息（核心原生路径会忽略，这里保持一致）
-        if (!message.some((seg: any) => seg && OB11_EXTRA_SEGMENT_TYPES.has(seg.type))) return;
+        if (!Array.isArray(message)) {
+            logger.debug(`ob11 事件消息为字符串（${String(message).slice(0, 50)}），由核心原生路径处理，跳过`);
+            return;
+        }
+        if (event.user_id === event.self_id) {
+            logger.debug(`ob11 事件消息来自机器人自身（${event.user_id}），跳过`);
+            return;
+        }
+        const segTypes = message.filter((seg: any) => seg && seg.type).map((seg: any) => seg.type);
+        if (!segTypes.some((t: string) => OB11_EXTRA_SEGMENT_TYPES.has(t))) {
+            logger.debug(`ob11 事件消息无额外段（types=[${segTypes.join(',')}]），由核心原生路径处理，跳过`);
+            return;
+        }
+        logger.info(`[debug] ob11 额外消息接收: ${event.message_type === 'group' ? '群' : '私聊'} uid=${event.user_id} segTypes=[${segTypes.join(',')}]`);
 
         // 按端点解析平台前缀（默认 QQ），并构造与核心回调一致的 ctx/msg
         const eps = seal.getEndPoints();
@@ -116,6 +139,7 @@ export class MessagePipeline {
             if (ep.userId === epId) break;
             if (ep.userId.endsWith(`:${event.self_id}`)) epId = ep.userId;
         }
+        logger.debug(`[debug] ob11 事件 端点解析完成 ep=${epId}`);
         const prefix = epId.includes(':') ? epId.slice(0, epId.indexOf(':')) : 'QQ';
         const uid = `${prefix}:${event.user_id}`;
         const isPrivate = event.message_type !== 'group';
@@ -123,7 +147,7 @@ export class MessagePipeline {
 
         const msg = createMsg(isPrivate ? 'private' : 'group', uid, gid);
         msg.platform = prefix;
-        msg.message = message as any; // 消息段数组，交给 expandOb11Segments 展开
+        // seal.Message.message 是 string 绑定，数组塞进去会被强转成字符串，段数组改走参数传入
         msg.time = event.time || 0;
         msg.rawId = event.message_id ?? 0;
         msg.sender.nickname = (event.sender && (event.sender.card || event.sender.nickname)) || '';
@@ -134,11 +158,12 @@ export class MessagePipeline {
             logger.warning(`ob11 事件消息未找到通信端点: ${epId}，跳过`);
             return;
         }
-        await MessagePipeline.handleNonCommand(ctx, msg);
+        logger.debug(`[debug] ob11 事件 ctx 构建完成 isPrivate=${ctx.isPrivate} player=${ctx.player && ctx.player.userId} group=${ctx.group && ctx.group.groupId}`);
+        await MessagePipeline.handleNonCommand(ctx, msg, message);
     }
 
     /** 非指令消息：过滤后进入会话，由智能体决定是否触发回复 */
-    static async handleNonCommand(ctx: seal.MsgContext, msg: seal.Message): Promise<void> {
+    static async handleNonCommand(ctx: seal.MsgContext, msg: seal.Message, ob11Segments?: any[]): Promise<void> {
         const { IGNORE_PRIVATE: disabledInPrivate, IGNORE_REGEX: ignoreRegex, IGNORE_CONDITION } = Config.received;
         const { TRIGGER_REGEX: triggerRegex, TRIGGER_CONDITION: triggerCondition } = Config.trigger;
 
@@ -172,13 +197,24 @@ export class MessagePipeline {
         const message = msg.message;
         // ob11 网络连接依赖以 OneBot 消息段数组传入时，走独立解析（卡片/视频/音乐/文件/消息节点/合并转发）；
         // 海豹原生 CQ 码字符串路径保持不变
-        const messageArray = Array.isArray(message)
+        if (Array.isArray(ob11Segments) || Array.isArray(message)) {
+            logger.debug('[debug] handleNonCommand 数组消息开始展开');
+        }
+        const messageArray = Array.isArray(ob11Segments)
+            ? await this.expandOb11Segments(ctx, ob11Segments)
+            : Array.isArray(message)
             ? await this.expandOb11Segments(ctx, message)
             : transformTextToArray(message);
+        if (Array.isArray(ob11Segments) || Array.isArray(message)) {
+            logger.debug('[debug] handleNonCommand 数组消息展开完成');
+        }
         // 正则匹配统一使用可读文本：原生路径保持原字符串，数组路径用展开后的文本
-        const messageText = Array.isArray(message)
+        const messageText = Array.isArray(ob11Segments) || Array.isArray(message)
             ? messageArray.map(item => item.type === 'text' ? ((item.data && item.data.text) || '') : `[${item.type}]`).join('')
             : message;
+        if (Array.isArray(ob11Segments) || Array.isArray(message)) {
+            logger.info(`[debug] ob11 消息展开: ${messageText.slice(0, 200)}`);
+        }
 
         // 忽略条件（豹语表达式）命中时直接忽略
         if (parseInt(seal.format(ctx, `{${IGNORE_CONDITION}}`)) === 1) {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,9 +6,27 @@ import { logger } from "./logger";
 import { getSession } from "./session/session_service";
 import Tool from "./tool/tool";
 import { triggerConditionMap } from "./tool/tools/tool_trigger";
-import { transformTextToArray } from "./utils/string";
+import { expandForwardMessage } from "./utils/ob11";
+import { MessageSegment, transformTextToArray } from "./utils/string";
 
 export class MessagePipeline {
+    /** 展开消息中的合并转发段（走 ob11 get_forward_msg，支持嵌套），返回替换后的消息段 */
+    private static async expandForwardSegments(epId: string, segs: MessageSegment[]): Promise<MessageSegment[]> {
+        const result: MessageSegment[] = [];
+        for (const seg of segs) {
+            if (seg.type === 'forward') {
+                const text = await expandForwardMessage(epId, (seg.data && seg.data.id) || '');
+                result.push({
+                    type: 'text',
+                    data: { text: text ? `【合并转发】\n${text}` : '[合并转发消息，展开失败]' }
+                });
+            } else {
+                result.push(seg);
+            }
+        }
+        return result;
+    }
+
     /** 非指令消息：过滤后进入会话，由智能体决定是否触发回复 */
     static async handleNonCommand(ctx: seal.MsgContext, msg: seal.Message): Promise<void> {
         const { IGNORE_PRIVATE: disabledInPrivate, IGNORE_REGEX: ignoreRegex, IGNORE_CONDITION } = Config.received;
@@ -42,7 +60,12 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        const messageArray = transformTextToArray(message);
+        let messageArray = transformTextToArray(message);
+
+        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段后再走后续过滤/触发
+        if (messageArray.some(seg => seg.type === 'forward')) {
+            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        }
 
         // 忽略条件（豹语表达式）命中时直接忽略
         if (parseInt(seal.format(ctx, `{${IGNORE_CONDITION}}`)) === 1) {
@@ -131,7 +154,7 @@ export class MessagePipeline {
     }
 
     /** 指令消息：记录 cmdArgs，并按配置决定是否写入会话上下文 */
-    static handleCommand(ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs): void {
+    static async handleCommand(ctx: seal.MsgContext, msg: seal.Message, cmdArgs: seal.CmdArgs): Promise<void> {
         if (Tool.cmdArgs === null) {
             Tool.cmdArgs = cmdArgs;
         }
@@ -147,7 +170,12 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        const messageArray = transformTextToArray(message);
+        let messageArray = transformTextToArray(message);
+
+        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段
+        if (messageArray.some(seg => seg.type === 'forward')) {
+            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        }
 
         const CQTypes = messageArray.filter(item => item.type !== 'text').map(item => item.type);
         if (CQTypes.length === 0 || CQTypes.every(item => CQ_TYPES_ALLOW.includes(item))) {
@@ -159,7 +187,7 @@ export class MessagePipeline {
     }
 
     /** 机器人自身发送的消息：转发给监听工具，并按配置决定是否记录上下文 */
-    static handleBotMessage(ctx: seal.MsgContext, msg: seal.Message): void {
+    static async handleBotMessage(ctx: seal.MsgContext, msg: seal.Message): Promise<void> {
         const uid = ctx.player!.userId;
         const gid = ctx.group!.groupId;
         const sid = ctx.isPrivate ? uid : gid;
@@ -168,7 +196,12 @@ export class MessagePipeline {
         session.checkActiveTimer(ctx);
 
         const message = msg.message;
-        const messageArray = transformTextToArray(message);
+        let messageArray = transformTextToArray(message);
+
+        // 展开合并转发（走 ob11 get_forward_msg），替换为可读文本段
+        if (messageArray.some(seg => seg.type === 'forward')) {
+            messageArray = await this.expandForwardSegments(ctx.endPoint.userId, messageArray);
+        }
 
         session.tool.listen.resolve?.(message); // 将消息传递给监听工具
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -11,7 +11,7 @@ import { createCtx, createMsg } from "./utils/seal";
 import { MessageSegment, parseCardToText, parseMusicToText, transformTextToArray } from "./utils/string";
 
 /** 海豹核心原生 milky 接收路径会过滤掉的段类型，只能通过 ob11 依赖的事件分发（milky → OB11 转接）收到 */
-const OB11_EXTRA_SEGMENT_TYPES = new Set(['json', 'video', 'file', 'node', 'forward', 'music', 'xml', 'markdown', 'market_face']);
+const OB11_EXTRA_SEGMENT_TYPES = new Set(['record', 'json', 'video', 'file', 'node', 'forward', 'music', 'xml', 'markdown', 'market_face']);
 
 export class MessagePipeline {
     /** ob11 数组消息段 → MessageSegment[]：把卡片/视频/音乐/文件/消息节点/合并转发展开为文本段，其余段保留 */
@@ -24,6 +24,11 @@ export class MessagePipeline {
             switch (seg.type) {
                 case 'json': {
                     result.push({ type: 'text', data: { text: parseCardToText(data.data) } });
+                    break;
+                }
+                case 'record': {
+                    // milky 适配器会丢弃语音段，这里由 ob11 转接事件补收并转成可读文本
+                    result.push({ type: 'text', data: { text: '【语音】' } });
                     break;
                 }
                 case 'file': {

--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -94,7 +94,7 @@ async function forwardSegmentsToText(epId: string, message: any): Promise<string
             case 'at': text += `@${(seg.data && seg.data.qq) || ''} `; break;
             case 'face': text += `[表情${(seg.data && seg.data.id) || ''}]`; break;
             case 'image': text += '[图片]'; break;
-            case 'record': text += '[语音]'; break;
+            case 'record': text += '【语音】'; break;
             case 'video': text += `【视频】${(seg.data && (seg.data.file || seg.data.url)) || ''}`; break;
             case 'file': text += `【文件】${(seg.data && (seg.data.name || seg.data.file || seg.data.file_id)) || ''}`; break;
             case 'json': text += parseCardToText(seg.data && seg.data.data); break;

--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -75,6 +75,40 @@ export async function getForwardMessage(epId: string, id: string): Promise<any[]
     }
 }
 
+/** 获取群文件下载 URL（走 ob11 get_group_file_download_url） */
+export async function getGroupFileDownloadUrl(epId: string, group_id: string, file_id: string, busid?: string): Promise<string> {
+    const net = getNet();
+    if (!net) return '';
+    try {
+        const data = await net.callApi(epId, 'get_group_file_download_url', {
+            group_id,
+            file_id,
+            busid: busid ? Number(busid) : undefined
+        });
+        return (data && data.url) || '';
+    } catch (e) {
+        logger.error(`获取群文件 ${file_id} 下载地址失败：${e}`);
+        return '';
+    }
+}
+
+/** 获取私聊文件下载 URL（走 ob11 get_private_file_download_url） */
+export async function getPrivateFileDownloadUrl(epId: string, user_id: string, file_id: string, busid?: string): Promise<string> {
+    const net = getNet();
+    if (!net) return '';
+    try {
+        const data = await net.callApi(epId, 'get_private_file_download_url', {
+            user_id,
+            file_id,
+            busid: busid ? Number(busid) : undefined
+        });
+        return (data && data.url) || '';
+    } catch (e) {
+        logger.error(`获取私聊文件 ${file_id} 下载地址失败：${e}`);
+        return '';
+    }
+}
+
 /** 合并转发单条消息内容转可读文本（支持嵌套 forward） */
 async function forwardSegmentsToText(epId: string, message: any): Promise<string> {
     if (typeof message === 'string') return message;

--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -62,6 +62,63 @@ export async function getStrangerInfo(epId: string, user_id: string): Promise<an
     }
 }
 
+/** 获取合并转发消息（OneBot get_forward_msg），返回消息数组 */
+export async function getForwardMessage(epId: string, id: string): Promise<any[]> {
+    const net = getNet();
+    if (!net) return [];
+    try {
+        const data = await net.callApi(epId, 'get_forward_msg', { id });
+        return (data && Array.isArray(data.messages)) ? data.messages : [];
+    } catch (e) {
+        logger.error(`获取合并转发消息 ${id} 失败：${e}`);
+        return [];
+    }
+}
+
+/** 合并转发单条消息内容转可读文本（支持嵌套 forward） */
+async function forwardSegmentsToText(epId: string, message: any): Promise<string> {
+    if (typeof message === 'string') return message;
+    if (!Array.isArray(message)) return '';
+
+    let text = '';
+    for (const seg of message) {
+        if (!seg || typeof seg !== 'object') continue;
+        switch (seg.type) {
+            case 'text': text += (seg.data && seg.data.text) || ''; break;
+            case 'at': text += `@${(seg.data && seg.data.qq) || ''} `; break;
+            case 'face': text += `[表情${(seg.data && seg.data.id) || ''}]`; break;
+            case 'image': text += '[图片]'; break;
+            case 'record': text += '[语音]'; break;
+            case 'video': text += '[视频]'; break;
+            case 'forward': {
+                const sub = await getForwardMessage(epId, (seg.data && seg.data.id) || '');
+                text += await forwardMessagesToText(epId, sub);
+                break;
+            }
+            default: text += `[${seg.type}]`;
+        }
+    }
+    return text;
+}
+
+/** 合并转发消息数组转可读文本（发送者 + 内容） */
+async function forwardMessagesToText(epId: string, messages: any[]): Promise<string> {
+    const lines: string[] = [];
+    for (const m of messages) {
+        const sender = m.sender || {};
+        const name = sender.card || sender.nickname || `用户${sender.user_id || ''}`;
+        const content = await forwardSegmentsToText(epId, m.message);
+        lines.push(`${name}: ${content}`);
+    }
+    return lines.join('\n');
+}
+
+/** 展开合并转发消息 id，返回可读文本（含嵌套） */
+export async function expandForwardMessage(epId: string, id: string): Promise<string> {
+    const messages = await getForwardMessage(epId, id);
+    return forwardMessagesToText(epId, messages);
+}
+
 export async function getGroupMemberInfo(epId: string, group_id: string, user_id: string): Promise<any> {
     const net = getNet();
     if (!net) return null;

--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -1,7 +1,7 @@
 // ob11 API 封装：消息/群/好友/禁言等
 import { logger } from "../logger";
 
-import { MessageSegment } from "./string";
+import { MessageSegment, parseCardToText, parseMusicToText } from "./string";
 
 export function getNet() {
     const net = globalThis.net;
@@ -62,13 +62,19 @@ export async function getStrangerInfo(epId: string, user_id: string): Promise<an
     }
 }
 
-/** 获取合并转发消息（OneBot get_forward_msg），返回消息数组 */
+/** 获取合并转发消息（OneBot get_forward_msg），返回消息数组。
+ * 兼容 ob11 网络连接依赖 milky 转接的两种返回形态（均为 message 数组）：
+ *  - 平铺: [{ user_id, nickname, time, message: [...] }]
+ *  - node: [{ type: 'node', data: { user_id, nickname, time, content: [...] } }] */
 export async function getForwardMessage(epId: string, id: string): Promise<any[]> {
     const net = getNet();
     if (!net) return [];
     try {
         const data = await net.callApi(epId, 'get_forward_msg', { id });
-        return (data && Array.isArray(data.messages)) ? data.messages : [];
+        if (!data) return [];
+        if (Array.isArray(data.message)) return data.message;
+        if (Array.isArray(data.messages)) return data.messages;
+        return [];
     } catch (e) {
         logger.error(`获取合并转发消息 ${id} 失败：${e}`);
         return [];
@@ -89,7 +95,15 @@ async function forwardSegmentsToText(epId: string, message: any): Promise<string
             case 'face': text += `[表情${(seg.data && seg.data.id) || ''}]`; break;
             case 'image': text += '[图片]'; break;
             case 'record': text += '[语音]'; break;
-            case 'video': text += '[视频]'; break;
+            case 'video': text += `【视频】${(seg.data && (seg.data.file || seg.data.url)) || ''}`; break;
+            case 'file': text += `【文件】${(seg.data && (seg.data.name || seg.data.file || seg.data.file_id)) || ''}`; break;
+            case 'json': text += parseCardToText(seg.data && seg.data.data); break;
+            case 'music': text += parseMusicToText(seg.data || {}); break;
+            case 'node': {
+                // 嵌套消息节点：复用整条消息的渲染逻辑（含发送者名）
+                text += await forwardMessagesToText(epId, [seg]);
+                break;
+            }
             case 'forward': {
                 const sub = await getForwardMessage(epId, (seg.data && seg.data.id) || '');
                 text += await forwardMessagesToText(epId, sub);
@@ -105,9 +119,12 @@ async function forwardSegmentsToText(epId: string, message: any): Promise<string
 async function forwardMessagesToText(epId: string, messages: any[]): Promise<string> {
     const lines: string[] = [];
     for (const m of messages) {
-        const sender = m.sender || {};
+        if (!m || typeof m !== 'object') continue;
+        // milky 转接的 node 形态：内容在 data.content；平铺形态：内容在 message
+        const nodeData = m.type === 'node' ? (m.data || {}) : null;
+        const sender = nodeData || m.sender || {};
         const name = sender.card || sender.nickname || `用户${sender.user_id || ''}`;
-        const content = await forwardSegmentsToText(epId, m.message);
+        const content = await forwardSegmentsToText(epId, nodeData ? nodeData.content : m.message);
         lines.push(`${name}: ${content}`);
     }
     return lines.join('\n');

--- a/src/utils/ob11.ts
+++ b/src/utils/ob11.ts
@@ -75,40 +75,6 @@ export async function getForwardMessage(epId: string, id: string): Promise<any[]
     }
 }
 
-/** 获取群文件下载 URL（走 ob11 get_group_file_download_url） */
-export async function getGroupFileDownloadUrl(epId: string, group_id: string, file_id: string, busid?: string): Promise<string> {
-    const net = getNet();
-    if (!net) return '';
-    try {
-        const data = await net.callApi(epId, 'get_group_file_download_url', {
-            group_id,
-            file_id,
-            busid: busid ? Number(busid) : undefined
-        });
-        return (data && data.url) || '';
-    } catch (e) {
-        logger.error(`获取群文件 ${file_id} 下载地址失败：${e}`);
-        return '';
-    }
-}
-
-/** 获取私聊文件下载 URL（走 ob11 get_private_file_download_url） */
-export async function getPrivateFileDownloadUrl(epId: string, user_id: string, file_id: string, busid?: string): Promise<string> {
-    const net = getNet();
-    if (!net) return '';
-    try {
-        const data = await net.callApi(epId, 'get_private_file_download_url', {
-            user_id,
-            file_id,
-            busid: busid ? Number(busid) : undefined
-        });
-        return (data && data.url) || '';
-    } catch (e) {
-        logger.error(`获取私聊文件 ${file_id} 下载地址失败：${e}`);
-        return '';
-    }
-}
-
 /** 合并转发单条消息内容转可读文本（支持嵌套 forward） */
 async function forwardSegmentsToText(epId: string, message: any): Promise<string> {
     if (typeof message === 'string') return message;

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -116,6 +116,38 @@ export interface MessageSegment {
     };
 }
 
+/** 解析 QQ 卡片消息（CQ:json / OB11 json 段的 data 字段），提取标题/描述/链接等可读文本 */
+export function parseCardToText(raw: any): string {
+    if (!raw) return '[卡片消息]';
+
+    let obj: any = null;
+    try {
+        obj = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    } catch (_e) {
+        return `[卡片消息] ${String(raw).slice(0, 200)}`;
+    }
+
+    const str = (v: any): string => (typeof v === 'string' && v.trim()) ? v.trim() : '';
+
+    // 常见卡片结构：view / meta.news / meta.detail 等
+    const view = (obj && (obj.view || (obj.meta && (obj.meta.news || obj.meta.detail || obj.meta.article)))) || obj || {};
+    const title = str(view.title) || str(obj.desc) || str(view.desc) || '';
+    const desc = str(view.desc) || str(view.summary) || (view.news && str(view.news.desc)) || '';
+    const url = str(view.url) || str(view.jumpUrl) || (view.news && str(view.news.jumpUrl)) || (view.detail && str(view.detail.jumpUrl)) || '';
+
+    const parts = [title, desc].filter(Boolean);
+    if (parts.length === 0) return '[卡片消息]';
+    return `【卡片】${parts.join('\n')}${url ? `\n${url}` : ''}`;
+}
+
+/** 音乐段转可读文本（data 为 qq/163 id 或 custom 对象） */
+export function parseMusicToText(data: any): string {
+    if (data && data.title) return `【音乐】${data.title}`;
+    const type = data && data.type ? String(data.type) : '';
+    const id = data && data.id ? String(data.id) : '';
+    return `【音乐】${type}${id ? ` ${id}` : ''}`;
+}
+
 export function transformTextToArray(text: string): MessageSegment[] {
     const segments = text.split(/(\[CQ:.*?\])/).filter(segment => segment);
     const messageArray: MessageSegment[] = [];


### PR DESCRIPTION
## 背景

海豹核心的原生 milky 接收路径（`platform_adapter_milky.go`）只保留 text / image / at / reply 四种消息段，卡片（json/light_app）、视频、文件、语音（record）、合并转发（forward）等段会被直接丢弃，纯这类消息整条不派发给插件。ob11 网络连接依赖把 milky 段转成 OneBot 消息段数组（milky → OB11 转接），只能通过其事件分发（`net.getEventDispatcher`）拿到这些段。

本 PR 让 aiplugin4 订阅 ob11 事件分发，把核心原生路径收不到的卡片/视频/音乐/文件/语音/消息节点/合并转发接入非指令管线（黑名单、忽略条件、触发、待机全部生效），原生 CQ 字符串路径保持不动。

## 改动

- `src/pipeline.ts`
  - 新增 `subscribeOb11Receive()`：订阅 ob11 依赖 `onMessageEvent`，ob11 依赖可能晚于本插件加载，采用轮询等待（最多 30s）
  - 新增 `handleOb11Event()`：只处理含额外段（record/json/video/file/node/forward/music/xml/markdown/market_face）的消息，跳过机器人自身消息，按段类型过滤避免与核心回调重复处理；构造 ctx/msg 后进入 `handleNonCommand`
  - 新增 `expandOb11Segments()`：卡片→`【卡片】标题/描述/链接`、视频→`【视频】`、文件→`【文件】名称`、音乐→`【音乐】`、语音→`【语音】`、节点/合并转发→递归展开文本，其余段保留
  - `handleNonCommand` 新增 `ob11Segments` 可选参数：ob11 事件路径直接传段数组（见下方根因），原生路径保持原有行为
  - 数组消息路径的正则匹配（忽略/触发关键词）改用展开后的可读文本
- `src/utils/ob11.ts`
  - 新增 `getForwardMessage`（兼容 ob11 依赖 `data.message` / `data.messages` 两种返回）、`expandForwardMessage` 递归展开合并转发（支持平铺与 node 两种返回形态）
  - 合并转发内容里的 json/music/file/node 段也能正确展开
- `src/utils/string.ts`：卡片/音乐解析抽成公共函数 `parseCardToText` / `parseMusicToText`，管线与转发展开复用
- `src/index.ts`：启动时挂载 ob11 事件分发订阅
- 调试日志：订阅成功、额外段接收、展开结果（信息级）；段类型跳过、端点/ctx 构建、展开过程（调试级，仅日志级别=调试时可见）

## 测试中发现并修复的根因

`seal.Message.message` 在 JS 绑定中是 Go 的 string 字段，把消息段数组赋进去会被 goja 强制转成字符串（`[object Object]`），导致最初依赖 `Array.isArray(msg.message)` 的展开分支永远不会触发、消息按 `[object Object]` 文本入库。已改为 `handleNonCommand(ctx, msg, ob11Segments)` 显式传段数组。

## 验证

- lint / `tsc --noEmit` / build / smoke 全部通过
- 面板实测（ob11 依赖 + NapCat OB11 直连）：
  - 订阅：PASS，群里真实文本/图片消息出现「无额外段…跳过」调试日志，证明 WS 事件流正常到达且不与核心路径重复
  - 合并转发：PASS，控制机器人（Fairy）发真实合并转发 → `get_forward_msg` 成功 → 展开为「Fairy: …」可读文本
  - 语音 record：PASS，经同一分发器注入合成 record 事件 → 展开为「【语音】」（群里无第二账号可发真实语音；milky 登录未配置，未测）