### PR TITLE
feat: 技能/MCP 配置兼容其他 agent 格式（SKILL.md 与 mcpServers JSON）

### DIFF
--- a/src/config/configs/tool.ts
+++ b/src/config/configs/tool.ts
@@ -13,7 +13,7 @@ export default class ToolConfig {
         seal.ext.registerTemplateConfig(ext, "可调用指令白名单", ['fun|jrrp', 'story|modu', 'coc7|st', 'coc7|ra', 'coc7|sc'], "每行一个 AI 可调用的海豹指令；格式：扩展名|指令名（指令与插件同名时可只写指令名）。示例：wifeOfTheDay|今日老婆、fun|jrrp、coc7|st。默认包含内置技能所需指令，可自行增删。修改后保存并重载 js", "工具");
         seal.ext.registerBoolConfig(ext, "是否允许调用所有指令", false, "开启后忽略白名单，允许调用所有可解析的指令；默认关闭，建议保持关闭以限制权限", "工具");
         seal.ext.registerTemplateConfig(ext, "提供给AI的牌堆名称", [''], "每行一个牌堆名，示例：克苏鲁的呼唤；没有的话建议把 draw_deck 加入不允许调用", "工具");
-        seal.ext.registerTemplateConfig(ext, "MCP服务器配置", [''], "每行一个 MCP 服务器：名称|地址|Token（Streamable HTTP）。\n示例：mcp-files-exec|http://127.0.0.1:3910|token\n地址换成你自己的 MCP 服务即可；修改后保存并重载js", "工具");
+        seal.ext.registerTemplateConfig(ext, "MCP服务器配置", [''], "每条配置项一个 MCP 服务器，支持两种格式：\n① 简写：名称|地址|Token\n② 标准 mcpServers JSON：直接粘贴 Claude/Cursor/.mcp.json 里的服务器配置，如 {\"mcpServers\":{\"mcp-files-exec\":{\"type\":\"http\",\"url\":\"http://127.0.0.1:3910\",\"headers\":{\"Authorization\":\"Bearer token\"}}}}，可带任意自定义 headers\n说明：stdio（command）服务器需拉起子进程，海豹环境不支持会自动跳过，请用 Streamable HTTP（type=http + url）；修改后保存并重载js", "工具");
         seal.ext.registerTemplateConfig(ext, "技能配置", [
             "今日人品|查询指定用户的今日人品值|使用 run_command 工具执行：action=call，command=\"fun|jrrp\"，args=[\"用户名或QQ号\"]；fun|jrrp 需在「可调用指令白名单」中",
             "COC模组抽取|随机抽取一个 COC 模组|使用 run_command 工具执行：action=call，command=\"story|modu\"，args=[\"roll\"]；story|modu 需在「可调用指令白名单」中",
@@ -21,7 +21,7 @@ export default class ToolConfig {
             "属性展示|展示指定玩家的 COC 全部个人属性|使用 run_command 工具执行：action=call，command=\"coc7|st\"，args=[\"show\",\"玩家名称或QQ号\"]；coc7|st 需在「可调用指令白名单」中",
             "属性检定|对指定玩家进行一次属性/技能检定（ra）|使用 run_command 工具执行：action=call，command=\"coc7|ra\"，args 按顺序：奖励/惩罚骰（可选，如 b、p3）、检定表达式（含难度等级或数值运算时直接用，普通属性名时用该属性，属性为0时补50）、检定原因（可选）；coc7|ra 需在「可调用指令白名单」中",
             "san检定|对指定玩家进行 san check（sc）|使用 run_command 工具执行：action=call，command=\"coc7|sc\"，args 按顺序：奖励/惩罚骰（可选，如 b、p2）、表达式（成功时掉san/失败时掉san，如 0/1d6、0/1）；coc7|sc 需在「可调用指令白名单」中"
-        ], "每行一个技能：名称|描述|内容；默认包含基于 run_command 统一调用的指令技能（今日人品/COC模组/属性展示/检定等），指令需加入「可调用指令白名单」，可自行增删。示例：骰点|TRPG百分比检定|使用 1d100 进行检定，出目小于等于技能值即成功，1为大成功，100为大失败\nAI 可通过 use_skill 工具按需调用", "工具");
+        ], "每条配置项一个技能，支持三种格式：\n① 旧格式：名称|描述|内容\n② JSON：{\"name\":\"骰点\",\"description\":\"...\",\"content\":\"...\"}\n③ 标准 SKILL.md：直接粘贴其他 agent（Claude/Codex/Cursor）的技能文件，--- 开头的 frontmatter 里写 name/description，正文为技能内容\n默认包含基于 run_command 统一调用的指令技能（今日人品/COC模组/属性展示/检定等），指令需加入「可调用指令白名单」，可自行增删。AI 可通过 use_skill 工具按需调用", "工具");
         seal.ext.registerOptionConfig(ext, "ai语音使用的音色", '傲娇少女', [
             "小新",
             "猴哥",

--- a/src/tool/mcp.ts
+++ b/src/tool/mcp.ts
@@ -8,6 +8,7 @@ interface MCPServer {
     name: string;
     url: string;
     token: string;
+    headers: { [key: string]: string };
 }
 
 interface MCPToolDef {
@@ -26,36 +27,92 @@ interface MCPServerState {
 const TOOLS_CACHE_TTL = 60 * 1000; // 工具列表缓存 60s
 const serverStates: { [name: string]: MCPServerState } = {};
 
-function getMCPServers(): MCPServer[] {
-    return seal.ext.getTemplateConfig(ext, "MCP服务器配置")
-        .map(line => (line || '').trim())
-        .filter(Boolean)
-        .map(line => {
-            // 支持 JSON 格式：{"name":"qq","url":"http://...","token":"..."}
-            if (line.startsWith('{')) {
-                try {
-                    const j = JSON.parse(line);
-                    return { name: String(j.name || '').trim(), url: String(j.url || '').trim(), token: String(j.token || '').trim() };
-                } catch (e) {
-                    Logger.error(`MCP服务器配置 JSON 解析失败: ${e instanceof Error ? e.message : String(e)}，内容: ${line}`);
-                    return { name: '', url: '', token: '' };
-                }
-            }
-            const [name, url, token = ''] = line.split('|').map(s => s.trim());
-            return { name, url, token };
-        })
-        .filter(s => s.name && s.url);
+/** 归一化一个 MCP 服务器配置（兼容 Claude Desktop / Cursor .mcp.json 的 mcpServers 条目） */
+function normalizeMCPServer(name: string, cfg: any): MCPServer | null {
+    if (typeof cfg === 'string') {
+        // 简写：{ "name": "http://..." }
+        return { name, url: cfg, token: '', headers: {} };
+    }
+    if (!cfg || typeof cfg !== 'object') return null;
+
+    // stdio 需要拉起子进程，海豹 goja 环境不支持，明确提示后跳过
+    if (cfg.command) {
+        Logger.warning(`MCP 服务器 ${name} 使用 stdio 传输，海豹运行环境无法拉起进程，已跳过；请改用 Streamable HTTP（type=http + url）`);
+        return null;
+    }
+    const type = String(cfg.type || 'http').toLowerCase();
+    if (type !== 'http' && type !== 'streamable-http') {
+        Logger.warning(`MCP 服务器 ${name} 传输类型 ${type} 不受支持（当前仅支持 Streamable HTTP），已跳过`);
+        return null;
+    }
+
+    const headers: { [key: string]: string } = {};
+    if (cfg.headers && typeof cfg.headers === 'object') {
+        for (const [key, value] of Object.entries(cfg.headers)) {
+            if (typeof value === 'string' && value) headers[key] = value;
+        }
+    }
+    let token = String(cfg.token || '').trim();
+    if (token && !headers['Authorization']) headers['Authorization'] = `Bearer ${token}`;
+    // 未单独给 token 时，从 headers 的 Authorization 里取，保持请求逻辑一致
+    const auth = headers['Authorization'] || '';
+    if (!token && auth.startsWith('Bearer ')) token = auth.slice(7).trim();
+
+    return {
+        name: String(cfg.name || name || '').trim(),
+        url: String(cfg.url || '').trim(),
+        token,
+        headers
+    };
 }
 
-async function mcpRequest(url: string, token: string, payload: object, sessionId?: string): Promise<{ status: number, body: any, sessionId?: string }> {
+function getMCPServers(): MCPServer[] {
+    const servers: MCPServer[] = [];
+    for (const line of seal.ext.getTemplateConfig(ext, "MCP服务器配置").map(l => (l || '').trim()).filter(Boolean)) {
+        if (line.startsWith('{') || line.startsWith('[')) {
+            try {
+                const j = JSON.parse(line);
+                // 标准 mcpServers 块：{"mcpServers":{"名称":{...}}}（Claude Desktop / Cursor .mcp.json）
+                if (j && typeof j === 'object' && j.mcpServers && typeof j.mcpServers === 'object') {
+                    for (const [name, cfg] of Object.entries(j.mcpServers)) {
+                        const s = normalizeMCPServer(name, cfg);
+                        if (s) servers.push(s);
+                    }
+                    continue;
+                }
+                // JSON 数组：[{name/url/type/headers...}]
+                if (Array.isArray(j)) {
+                    for (const cfg of j) {
+                        const s = normalizeMCPServer(String((cfg && (cfg.name || cfg.url)) || 'mcp'), cfg);
+                        if (s) servers.push(s);
+                    }
+                    continue;
+                }
+                // 单服务器 JSON：{"name":"qq","url":"http://...","token":"..."} 或 {name: "url"}
+                const s = normalizeMCPServer(String(j.name || j.url || ''), j);
+                if (s) servers.push(s);
+            } catch (e) {
+                Logger.error(`MCP服务器配置 JSON 解析失败: ${e instanceof Error ? e.message : String(e)}，内容: ${line}`);
+            }
+            continue;
+        }
+        // 旧格式：名称|地址|Token
+        const [name, url, token = ''] = line.split('|').map(s => s.trim());
+        servers.push({ name, url, token, headers: {} });
+    }
+    return servers.filter(s => s.name && s.url);
+}
+
+async function mcpRequest(server: MCPServer, payload: object, sessionId?: string): Promise<{ status: number, body: any, sessionId?: string }> {
     const headers: { [key: string]: string } = {
         "Content-Type": "application/json",
-        "Accept": "application/json, text/event-stream"
+        "Accept": "application/json, text/event-stream",
+        ...server.headers
     };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    if (server.token && !headers["Authorization"]) headers["Authorization"] = `Bearer ${server.token}`;
     if (sessionId) headers["Mcp-Session-Id"] = sessionId;
 
-    const response = await fetch(url, {
+    const response = await fetch(server.url, {
         method: 'POST',
         headers,
         body: JSON.stringify(payload)
@@ -94,7 +151,7 @@ function formatError(status: number, body: any): string {
 }
 
 async function initialize(server: MCPServer): Promise<string | undefined> {
-    const res = await mcpRequest(server.url, server.token, {
+    const res = await mcpRequest(server, {
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
@@ -108,12 +165,12 @@ async function initialize(server: MCPServer): Promise<string | undefined> {
         throw new Error(`MCP initialize 失败: ${formatError(res.status, res.body)}`);
     }
     const sessionId = res.sessionId;
-    await mcpRequest(server.url, server.token, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId);
+    await mcpRequest(server, { jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId);
     return sessionId;
 }
 
 async function listTools(server: MCPServer, sessionId: string): Promise<MCPToolDef[]> {
-    const res = await mcpRequest(server.url, server.token, { jsonrpc: '2.0', id: 2, method: 'tools/list' }, sessionId);
+    const res = await mcpRequest(server, { jsonrpc: '2.0', id: 2, method: 'tools/list' }, sessionId);
     if (res.body && res.body.error) {
         throw new Error(`MCP tools/list 失败: ${formatError(res.status, res.body)}`);
     }
@@ -122,7 +179,7 @@ async function listTools(server: MCPServer, sessionId: string): Promise<MCPToolD
 }
 
 async function doCallTool(server: MCPServer, sessionId: string, name: string, args: any): Promise<string> {
-    const res = await mcpRequest(server.url, server.token, {
+    const res = await mcpRequest(server, {
         jsonrpc: '2.0',
         id: 3,
         method: 'tools/call',

--- a/src/tool/skills.ts
+++ b/src/tool/skills.ts
@@ -13,32 +13,61 @@ interface Skill {
 const MAX_SKILL_CONTENT_LENGTH = 4000; // 单次返回的技能内容上限
 const MAX_REF_DEPTH = 2; // 技能间引用的最大解析深度
 
+/** 解析标准 SKILL.md frontmatter（--- 开头，name/description 键值对），兼容 Claude/Codex/Cursor 等 agent 的技能文件 */
+function parseSkillFrontmatter(raw: string): { name?: string, description?: string } {
+    const meta: { name?: string, description?: string } = {};
+    for (const line of raw.split('\n')) {
+        const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+        if (!m) continue;
+        const key = m[1].toLowerCase();
+        const value = m[2].trim().replace(/^['"]|['"]$/g, '');
+        if (!value) continue;
+        if (key === 'name') meta.name = value;
+        else if (key === 'description') meta.description = value;
+    }
+    return meta;
+}
+
+/** 解析单条技能配置：JSON / 标准 SKILL.md / 旧格式 名称|描述|内容 */
+function parseSkillEntry(line: string): { name: string, description: string, content: string } {
+    // JSON 格式：{"name":"骰点","description":"...","content":"..."}
+    if (line.startsWith('{')) {
+        try {
+            const j = JSON.parse(line);
+            return {
+                name: String(j.name || '').trim(),
+                description: String(j.description || '').trim(),
+                content: String(j.content || '').trim()
+            };
+        } catch (e) {
+            Logger.error(`技能配置 JSON 解析失败: ${e instanceof Error ? e.message : String(e)}，内容: ${line}`);
+            return { name: '', description: '', content: '' };
+        }
+    }
+    // 标准 SKILL.md：--- frontmatter（name/description）--- 正文，可直接粘贴其他 agent 的技能文件
+    const fmMatch = line.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+    if (fmMatch) {
+        const meta = parseSkillFrontmatter(fmMatch[1]);
+        return {
+            name: (meta.name || '').trim(),
+            description: (meta.description || '').trim(),
+            content: fmMatch[2].trim()
+        };
+    }
+    // 旧格式：名称|描述|内容
+    const [name, description = '', ...rest] = line.split('|');
+    return {
+        name: name.trim(),
+        description: description.trim(),
+        content: rest.join('|').trim()
+    };
+}
+
 function getSkills(): Skill[] {
     return seal.ext.getTemplateConfig(ext, "技能配置")
-        .map(line => (line || '').trim())
+        .map(line => (line || '').replace(/\r\n/g, '\n').trim())
         .filter(Boolean)
-        .map(line => {
-            // 支持 JSON 格式：{"name":"骰点","description":"...","content":"..."}
-            if (line.startsWith('{')) {
-                try {
-                    const j = JSON.parse(line);
-                    return {
-                        name: String(j.name || '').trim(),
-                        description: String(j.description || '').trim(),
-                        content: String(j.content || '').trim()
-                    };
-                } catch (e) {
-                    Logger.error(`技能配置 JSON 解析失败: ${e instanceof Error ? e.message : String(e)}，内容: ${line}`);
-                    return { name: '', description: '', content: '' };
-                }
-            }
-            const [name, description = '', ...rest] = line.split('|');
-            return {
-                name: name.trim(),
-                description: description.trim(),
-                content: rest.join('|').trim()
-            };
-        })
+        .map(parseSkillEntry)
         .filter(s => s.name);
 }
 


### PR DESCRIPTION
## 目的

让 aiplugin4 的「技能配置」和「MCP服务器配置」能直接复用其他 agent（Claude / Codex / Cursor）现成的配置，拿来就能用，不用手动转成插件专属格式。

## 改动

### 技能配置（skills）

新增标准 **SKILL.md** 格式支持：直接把技能文件原样粘进一条配置项即可，`---` frontmatter 里的 `name` / `description` 自动作为技能名与摘要，正文作为技能内容。

现在三种格式都支持：

1. 旧格式：`名称|描述|内容`
2. JSON：`{"name":"...","description":"...","content":"..."}`
3. 标准 SKILL.md（Claude/Codex/Cursor 通用）：

```markdown
---
name: 骰点
description: TRPG 百分比检定
---
# 骰点
使用 1d100 进行检定……
```

### MCP 服务器配置（mcp）

新增标准 **mcpServers JSON** 格式支持：直接粘贴 Claude Desktop / Cursor `.mcp.json` 里的服务器块，`type=http` 走现有 Streamable HTTP 客户端；支持任意自定义 `headers`（Authorization、X-Api-Key 等）、`token` 简写。

```json
{"mcpServers":{"mcp-files-exec":{"type":"http","url":"http://127.0.0.1:3910","headers":{"Authorization":"Bearer token"}}}}
```

说明：

- `command`（stdio）服务器需要拉起子进程，海豹 goja 环境不支持，会打印明确警告并跳过，不会导致注册失败
- `type=sse` 暂不支持（当前仅 Streamable HTTP），同样提示后跳过
- 旧格式 `名称|地址|Token` 保持兼容

## 验证

- lint / `tsc --noEmit` / build / smoke 通过
- 解析逻辑样本验证：SKILL.md（含多余 frontmatter 字段）、旧格式、JSON、mcpServers 块（自定义 headers / token 简写 / stdio 跳过 / sse 跳过）均符合预期