### PR TITLE
feat: 多模态模型支持——图片模型配置 use=chat 时，上下文图片直接传给模型

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -3,6 +3,7 @@ import Config from "../config/config";
 import { ext } from "../config/config";
 import Logger, { logger } from "../logger";
 import ChatModel from "../model/chat";
+import ImageModel from "../model/image";
 import Model from "../model/model";
 import { ChatModelUse } from "../model/types";
 import Image from "../resource/image";
@@ -55,6 +56,19 @@ export default class Agent {
         return null;
     }
 
+    /**
+     * 当前会话使用的对话模型是否为多模态：
+     * 1) 直接命中「图片模型」里 use=chat 的条目（ImageModel 实例）；
+     * 2) 对话模型的名字出现在「图片模型」列表里（即该模型声明为视觉/多模态模型）。
+     * 多模态时上下文中的图片以 image_url 内容块直接传给模型，而不是文本标签。
+     */
+    private isMultimodalChat(session: Session): boolean {
+        const model = Model.getChatModel('chat', session.setting.modelName);
+        if (!model) return false;
+        if (model instanceof ImageModel) return true;
+        return Model.imageModels.some(im => im.name === model.name);
+    }
+
     async chat(prompt: string): Promise<string> {
         const model = Model.getChatModel(this.use) as ChatModel;
         if (!model) return '';
@@ -102,7 +116,7 @@ export default class Agent {
 
         for (let retry = 1; retry <= MaxRetry; retry++) {
             trace.beginTurn();
-            const messages = await handleMessages(ctx, session);
+            const messages = await handleMessages(ctx, session, this.isMultimodalChat(session));
             const { content: raw_reply, tool_calls } = await streamService.sendChatRequest(messages, toolInfos || [], tool_choice || 'auto', session.setting.modelName);
             result = await handleReply(ctx, msg, session, raw_reply);
 
@@ -208,7 +222,7 @@ export default class Agent {
 
         await session.stopCurrentChatStream();
 
-        const messages = await handleMessages(ctx, session);
+        const messages = await handleMessages(ctx, session, this.isMultimodalChat(session));
         const id = await streamService.startStream(messages, session.setting.modelName);
         if (!id) return;
 

--- a/src/agent/stream.ts
+++ b/src/agent/stream.ts
@@ -8,6 +8,7 @@ import Model from "../model/model";
 import { requestModel } from "../model/provider";
 import { ToolCall } from "../tool/types";
 import { UsageManager } from "../usage";
+import { RequestMessage } from "../utils/message";
 import { withTimeout } from "../utils/utils";
 
 export class streamService {
@@ -79,12 +80,7 @@ export class streamService {
     /**
      * 非流式对话请求（从旧 src/service.ts 的 sendChatRequest 移植，改用新 Model 配置）
      */
-    static async sendChatRequest(messages: {
-        role: string,
-        content: string,
-        tool_calls?: ToolCall[],
-        tool_call_id?: string
-    }[], tools: any[], tool_choice: string, modelName: string = ''): Promise<{ content: string, tool_calls: ToolCall[] }> {
+    static async sendChatRequest(messages: RequestMessage[], tools: any[], tool_choice: string, modelName: string = ''): Promise<{ content: string, tool_calls: ToolCall[] }> {
         const model = Model.getChatModel('chat', modelName) as ChatModel;
         if (!model) {
             logger.error('未找到可用的对话模型');

--- a/src/config/configs/model.ts
+++ b/src/config/configs/model.ts
@@ -33,14 +33,14 @@ max_tokens = 8192                   # 可选`
             `# 使用toml格式
 name = "glm-4v"                     # 必填，模型名
 api_key = "sk-xxxx"                 # 必填，API 密钥
-use = ["image-understanding"]       # 必填，用途：image-understanding
+use = ["image-understanding"]       # 必填，用途：image-understanding / chat（多模态对话）
 provider = "zhipu"                  # 可选，服务商，省略时自动识别
 base_url = "https://open.bigmodel.cn/api/paas/v4"  # 可选，API 地址，省略时取服务商默认
 
 [body]                              # 可选，请求参数覆盖；默认 max_tokens=4096、stop=null、stream=false
 temperature = 1                     # 可选
 max_tokens = 4096                   # 可选`
-        ], '每行一个图片模型（TOML）。必填：name（模型名）、api_key（API 密钥）、use（用途）。可选：provider（服务商，省略时按模型名自动识别：zhipu/alibaba/openai/google/siliconflow）、base_url（API 地址，省略时按服务商取默认）、body（请求参数覆盖）。use 可选值：image-understanding（图片理解/图片转文字）。body 未配置时使用 max_tokens=4096、stop=null、stream=false。下方默认值即完整示例，可直接修改。', "模型");
+        ], '每行一个图片模型（TOML）。必填：name（模型名）、api_key（API 密钥）、use（用途）。可选：provider（服务商，省略时按模型名自动识别：zhipu/alibaba/openai/google/siliconflow）、base_url（API 地址，省略时按服务商取默认）、body（请求参数覆盖）。use 可选值：image-understanding（图片理解/图片转文字）、chat（多模态对话：把该模型同时当作对话模型，用 .ai model 选择它后，上下文里的图片会以图片内容直接传给模型，不再转成文本标签；对话模型名字出现在本列表时同样按多模态处理）。body 未配置时使用 max_tokens=4096、stop=null、stream=false。下方默认值即完整示例，可直接修改。', "模型");
         seal.ext.registerTemplateConfig(ext, "嵌入模型", [
             `# 使用toml格式
 name = "text-embedding-v4"          # 必填，模型名

--- a/src/model/adapter.ts
+++ b/src/model/adapter.ts
@@ -108,6 +108,24 @@ function buildAnthropicMessages(messages: any[]): { system: string, messages: an
             continue;
         }
         let content: any = msg.content;
+        // 多模态内容块：OpenAI image_url → Anthropic image（base64 或 url 两种 source）
+        if (Array.isArray(content)) {
+            content = content.map((block: any) => {
+                if (block.type === 'image_url') {
+                    const url = (block.image_url && block.image_url.url) || '';
+                    const m = url.match(/^data:image\/([^;]+);base64,(.+)$/);
+                    if (m) {
+                        return {
+                            type: 'image',
+                            source: { type: 'base64', media_type: `image/${m[1]}`, data: m[2] }
+                        };
+                    }
+                    return { type: 'image', source: { type: 'url', url } };
+                }
+                if (block.type === 'text') return { type: 'text', text: block.text };
+                return block;
+            });
+        }
         if (role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
             const blocks: any[] = [];
             if (msg.content) blocks.push({ type: 'text', text: typeof msg.content === 'string' ? msg.content : '' });

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -47,6 +47,15 @@ export default class Model {
             if (namedAnyList.length > 0) {
                 return namedAnyList[0];
             }
+            // 图片模型里配置的多模态模型也可按名称用于 chat（use 含 chat 或未指定用途）
+            const namedImageList = Model.imageModels.filter(model => model.name === name && model.use.includes(use));
+            if (namedImageList.length > 0) {
+                return namedImageList[0];
+            }
+            const namedImageAnyList = Model.imageModels.filter(model => model.name === name && model.use.length === 0);
+            if (namedImageAnyList.length > 0) {
+                return namedImageAnyList[0];
+            }
             // 指定名称不存在时回退到全局选择
             return Model.getChatModel(use);
         }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -188,9 +188,9 @@ export class Session {
         return state;
     }
 
-    async getMessages(): Promise<RequestMessage[]> {
+    async getMessages(multimodal = false): Promise<RequestMessage[]> {
         if (this.lastCtx) {
-            return await handleMessages(this.lastCtx, this);
+            return await handleMessages(this.lastCtx, this, multimodal);
         }
         return (this.context.messages as any[]).map(m => ({
             role: m.role,
@@ -198,8 +198,9 @@ export class Session {
         }));
     }
 
+    /** 图片对话使用的消息：多模态模型直接携带图片内容块 */
     async getImageMessages(): Promise<RequestMessage[]> {
-        return this.getMessages();
+        return this.getMessages(true);
     }
 
     checkIgnoredUserId(userId: string): boolean {

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,13 +1,22 @@
 // 消息构建：system prompt 组装与 body 解析
 import Config from "../config/config";
+import { logger } from "../logger";
 import { buildSystemPromptContent } from "../prompt/builder";
+import Image from "../resource/image";
 import { Session } from "../session/session";
 import { ToolInfo } from "../tool/types";
 import { ToolCall } from "../tool/types";
 
+import { withTimeout } from "./utils";
+
+/** OpenAI 兼容内容：纯文本，或多模态内容块（文本 + 图片） */
+export type RequestMessageContent =
+    | string
+    | Array<{ type: 'text', text: string } | { type: 'image_url', image_url: { url: string } }>;
+
 export interface RequestMessage {
     role: string;
-    content: string;
+    content: RequestMessageContent;
     tool_calls?: ToolCall[];
     tool_call_id?: string;
 }
@@ -97,7 +106,7 @@ function buildContextMessages(systemMessage: ContextMessage, messages: ContextMe
     return contextMessages;
 }
 
-export async function handleMessages(ctx: seal.MsgContext, session: Session): Promise<RequestMessage[]> {
+export async function handleMessages(ctx: seal.MsgContext, session: Session, multimodal = false): Promise<RequestMessage[]> {
     const systemMessage = await buildSystemMessage(ctx, session);
     const samplesMessages = buildSamplesMessages(ctx);
     const contextMessages = buildContextMessages(systemMessage, session.context.messages as ContextMessage[]);
@@ -150,12 +159,12 @@ export async function handleMessages(ctx: seal.MsgContext, session: Session): Pr
         if (!toolCallIdSet.has(id)) messages.splice(i, 1);
     }
 
-    return messages.map(message => ({
+    return await Promise.all(messages.map(async message => ({
         role: message.role,
-        content: buildContent(message),
+        content: multimodal ? await buildMultimodalContent(message) : buildContent(message),
         tool_calls: message.toolCalls || message.tool_calls,
         tool_call_id: message.toolCallId || message.tool_call_id
-    }));
+    })));
 }
 
 export function buildContent(message: ContextMessage): string {
@@ -164,6 +173,49 @@ export function buildContent(message: ContextMessage): string {
     }
     if (message.text) return message.text;
     return '';
+}
+
+/** 解析 <|img:...|> 标签里的图片 id（兼容 user_avatar/group_avatar 前缀与「id:描述」形式） */
+function resolveImageById(id: string): Image | null {
+    if (/^user_avatar[:?]/.test(id)) return Image.getUserAvatar(id.replace(/^user_avatar[:?]/, ''));
+    if (/^group_avatar[:?]/.test(id)) return Image.getGroupAvatar(id.replace(/^group_avatar[:?]/, ''));
+    const img = Image.get(id);
+    if (img) return img;
+    // 兼容 <|img:imageId:描述|>：描述部分可能带冒号，取首个冒号前作为图片 id
+    return Image.get(id.split(':')[0]);
+}
+
+/**
+ * 多模态消息内容：把用户消息里的 <|img:...|> 图片标签转成 image_url 内容块直接传给模型，
+ * 而不是让模型只看到文本标签；无法解析的图片（如本地路径无可用 URL）保留原标签。
+ */
+export async function buildMultimodalContent(message: ContextMessage): Promise<RequestMessageContent> {
+    if (message.role !== 'user') return buildContent(message);
+    const text = buildContent(message);
+    if (!text.includes('img')) return text;
+
+    const parts: Array<{ type: 'text', text: string } | { type: 'image_url', image_url: { url: string } }> = [];
+    const segs = text.split(/([<＜][\|│｜][^:：]+[:：]?\s?.+?(?:[\|│｜][>＞]|[\|│｜>＞]))/).filter(Boolean);
+    for (const seg of segs) {
+        const match = seg.match(/^[<＜][\|│｜]img[:：]?\s?(.+?)(?:[\|│｜][>＞]|[\|│｜>＞])$/i);
+        if (!match) {
+            parts.push({ type: 'text', text: seg });
+            continue;
+        }
+        const image = resolveImageById(match[1].trim());
+        // URL 图片优先转成 base64（模型常无法直接访问 QQ 临时链接）；转换失败保留原 URL
+        if (image && image.type === 'url' && !image.base64) {
+            try {
+                await withTimeout(() => image.urlToBase64(), 10000);
+            } catch (e) {
+                logger.warning(`多模态图片转 base64 失败，改用原 URL: ${image.imageId}（${e instanceof Error ? e.message : String(e)}）`);
+            }
+        }
+        const src = image && image.src;
+        if (src) parts.push({ type: 'image_url', image_url: { url: src } });
+        else parts.push({ type: 'text', text: seg });
+    }
+    return parts;
 }
 
 export function parseBody(template: string[], messages: any[], tools: ToolInfo[], tool_choice: string) {


### PR DESCRIPTION
## 目的

支持多模态模型：在「图片模型」里配置的多模态模型（use=chat）可以直接当对话模型用，上下文中的图片以 image_url 内容块**直接传给模型**，不再转成 `<|img:...|>` 文本标签。

## 改动

- `src/config/configs/model.ts`：图片模型 TOML 的 use 增加 `chat`（多模态对话）用途，说明文案同步更新
- `src/model/model.ts`：`getChatModel` 按名称解析时也会在图片模型列表中查找（use 含 chat 或未指定用途），因此 `.ai model <名称>` 可以选择图片模型里配置的多模态模型
- `src/agent/agent.ts`：`isMultimodalChat` 判定当前对话模型是否多模态（命中图片模型列表的模型名，或本身就是 ImageModel 实例），多模态时 `handleMessages` 走图片直传
- `src/utils/message.ts`：`buildMultimodalContent` 把用户消息里的 `<|img:...|>` 标签转成 `image_url` 内容块（支持 user_avatar/group_avatar 前缀、`id:描述` 形式）；URL 图片优先转 base64（10s 超时兜底，转换失败保留原 URL）；本地路径无可用 URL 的图片保留原标签
- `src/model/adapter.ts`：anthropic 适配层支持 OpenAI `image_url` 内容块 → Anthropic `image`（base64 / url 两种 source）
- `src/session/session.ts`：`getImageMessages` 返回多模态消息（图片对话直接携带图片）

## 使用方式

在「图片模型」配置里给多模态模型加 `use = ["chat"]`（可与 image-understanding 并存）：

```toml
name = "qwen-vl-max"
api_key = "sk-xxxx"
use = ["image-understanding", "chat"]
provider = "alibaba"
```

然后 `.ai model qwen-vl-max` 选择它；此时上下文里收到的图片会以图片内容直接传给模型，不再只是文本标签。对话模型的名字出现在「图片模型」列表时同样按多模态处理。

## 验证

- lint / `tsc --noEmit` / build / smoke 通过