### PR TITLE
fix: MCP 默认 URL 补 /mcp 路径，自动改名增加超时保护

### DIFF
--- a/docs/08-相关后端项目.md
+++ b/docs/08-相关后端项目.md
@@ -13,7 +13,7 @@
 | `md-html-render` | Markdown/HTML 渲染为图片 | 37632 | 工具 → MCP服务器配置（md-html-render） |
 | `mcp-files-exec` | 本地文件读写/执行 | 3910 | 工具 → MCP服务器配置（mcp-files-exec） |
 
-`web-read`、`md-html-render` 与 `mcp-files-exec` 均为 **MCP（Streamable HTTP）** 服务：插件通过「工具 → MCP服务器配置」中的 `mcpServers` 块按标准格式接入（默认 `http://127.0.0.1:46799/mcp`、`http://127.0.0.1:37632/mcp`、`http://127.0.0.1:3910`）。其中 `web-read` / `md-html-render` 由内置包装工具（`web_read` / `render_markdown` / `render_html`）调用，不重复注册为 AI 工具；`mcp-files-exec` 的工具（文件读写/执行）直接注册为 AI 工具。这些后端的 REST 接口已移除，仅提供 MCP。
+`web-read`、`md-html-render` 与 `mcp-files-exec` 均为 **MCP（Streamable HTTP）** 服务：插件通过「工具 → MCP服务器配置」中的 `mcpServers` 块按标准格式接入（默认 `http://127.0.0.1:46799/mcp`、`http://127.0.0.1:37632/mcp`、`http://127.0.0.1:3910/mcp`）。其中 `web-read` / `md-html-render` 由内置包装工具（`web_read` / `render_markdown` / `render_html`）调用，不重复注册为 AI 工具；`mcp-files-exec` 的工具（文件读写/执行）直接注册为 AI 工具。这些后端的 REST 接口已移除，仅提供 MCP。
 
 ## 部署与一键管理
 

--- a/src/config/configs/tool.ts
+++ b/src/config/configs/tool.ts
@@ -19,7 +19,7 @@ export default class ToolConfig {
   "mcpServers": {
     "mcp-files-exec": {
       "type": "http",
-      "url": "http://127.0.0.1:3910",
+      "url": "http://127.0.0.1:3910/mcp",
       "headers": {
         "Authorization": "Bearer token"
       }

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -10,7 +10,7 @@ import User from "../session/user";
 import { ToolCall } from "../tool/types";
 import { getFriendList, getGroupList, getGroupMemberInfo, getGroupMemberList, getStrangerInfo, netExists } from "../utils/ob11";
 import { levenshteinDistance, stripInternalTags } from "../utils/string";
-import { TypeDescriptor } from "../utils/utils";
+import { TypeDescriptor, withTimeout } from "../utils/utils";
 
 import Message from "./message";
 import { AssistantMessage, AssistantMessageItem, MessageType, SystemUserMessageItem, ToolCallbackMessage, ToolCallsMessage, UserMessage, UserMessageItem } from "./types";
@@ -406,11 +406,19 @@ export class Context {
     async updateName(epId: string, gid: string, uid: string) {
         switch (this.autoNameMod) {
             case 1: {
-                await this.setName(epId, gid, uid, 'nickname');
+                try {
+                    await withTimeout(() => this.setName(epId, gid, uid, 'nickname'), 5000);
+                } catch (e) {
+                    Logger.warning(`自动改名（昵称）失败: ${e instanceof Error ? e.message : String(e)}`);
+                }
                 break;
             }
             case 2: {
-                await this.setName(epId, gid, uid, 'card');
+                try {
+                    await withTimeout(() => this.setName(epId, gid, uid, 'card'), 5000);
+                } catch (e) {
+                    Logger.warning(`自动改名（群名片）失败: ${e instanceof Error ? e.message : String(e)}`);
+                }
                 break;
             }
         }


### PR DESCRIPTION
## 变更内容

1. **MCP 默认 URL 补 /mcp 路径**：MCP服务器配置 默认值中 mcp-files-exec 的 url 由 http://127.0.0.1:3910 修正为 http://127.0.0.1:3910/mcp（与后端 Streamable HTTP 实际路径一致），并同步更新 docs/08-相关后端项目.md 中的默认地址说明。
2. **自动改名超时保护**：updateName 的昵称/群名片两个分支包 5 秒超时，ob11 依赖请求不 resolve 时不再让整条消息处理链路挂起，超时记录 warning 后继续。

## 实测结果（测试群）

- 上传新构建并重载 JS 后，面板日志确认 5 个 MCP 工具全部注册成功（read_file / list_dir / write_file / delete_file / run_command），无注册报错。
- .ai tool 列表新增 62-66 号 mcp-files-exec_* 工具。
- .ai tool call mcp-files-exec_list_dir --path=. 返回沙箱目录列表。
- .ai tool call mcp-files-exec_read_file --path=backend.json 返回文件内容。
- 面板日志无任何错误。

## 配置变动提示

MCP服务器配置 默认值已更新：旧值（无 /mcp 后缀）会导致 mcp-files-exec 初始化失败（HTTP 404）。已保存过旧默认值的用户需在面板 工具->MCP服务器配置 中把 mcp-files-exec 的 url 改为 http://127.0.0.1:3910/mcp（本次测试已在面板通过 WebUI API 同步）。